### PR TITLE
2016 general and reusable cleaning script

### DIFF
--- a/2016/20161108__wa__general__county.csv
+++ b/2016/20161108__wa__general__county.csv
@@ -1,0 +1,1584 @@
+county,office,district,party,candidate,votes
+Adams,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,1299
+Adams,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,3083
+Adams,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,9
+Adams,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,10
+Adams,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,22
+Adams,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,38
+Adams,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,183
+Adams,U.S. Senator,NA,Democratic,Patty Murray,1859
+Adams,U.S. Senator,NA,Republican,Chris Vance,2818
+Adams,U.S. Representative,4,Republican,Dan Newhouse,2402
+Adams,U.S. Representative,4,Republican,Clint Didier,1930
+Adams,Governor,NA,Democratic,Jay Inslee,1533
+Adams,Governor,NA,Republican,Bill Bryant,3151
+Adams,Lt. Governor,NA,Democratic,Cyrus Habib,1317
+Adams,Lt. Governor,NA,Republican,Marty McClendon,3171
+Adams,Secretary of State,NA,Republican,Kim Wyman,3394
+Adams,Secretary of State,NA,Democratic,Tina Podlodowski,1107
+Adams,State Treasurer,NA,Republican,Duane Davidson,2466
+Adams,State Treasurer,NA,Republican,Michael Waite,1575
+Adams,State Auditor,NA,Republican,Mark Miloscia,3020
+Adams,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,1449
+Adams,Attorney General,NA,Democratic,Bob Ferguson,2247
+Adams,Attorney General,NA,Libertarian,Joshua B. Trumbull,1888
+Adams,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,3230
+Adams,Commissioner of Public Lands,NA,Democratic,Hilary Franz,1234
+Adams,Superintendent of Public Instruction,NA,NA,Erin Jones,2022
+Adams,Superintendent of Public Instruction,NA,NA,Chris Reykdal,1917
+Adams,Insurance Commissioner,NA,Democratic,Mike Kreidler,1512
+Adams,Insurance Commissioner,NA,Republican,Richard Schrock,2900
+Adams,State Senator,9,G.O.P,Mark G. Schoesler,3941
+Adams,State Representative,9-1,Republican,Mary Dye,3399
+Adams,State Representative,9-1,Democratic,Jennifer Goulet,1118
+Adams,State Representative,9-2,Republican,Joe Schmick,3890
+Asotin,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,3134
+Asotin,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,5741
+Asotin,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,16
+Asotin,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,6
+Asotin,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,117
+Asotin,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,98
+Asotin,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,624
+Asotin,U.S. Senator,NA,Democratic,Patty Murray,4248
+Asotin,U.S. Senator,NA,Republican,Chris Vance,5497
+Asotin,U.S. Representative,5,Republican,Cathy McMorris Rodgers,6303
+Asotin,U.S. Representative,5,Democratic,Joe Pakootas,3445
+Asotin,Governor,NA,Democratic,Jay Inslee,4149
+Asotin,Governor,NA,Republican,Bill Bryant,5609
+Asotin,Lt. Governor,NA,Democratic,Cyrus Habib,3365
+Asotin,Lt. Governor,NA,Republican,Marty McClendon,6074
+Asotin,Secretary of State,NA,Republican,Kim Wyman,6477
+Asotin,Secretary of State,NA,Democratic,Tina Podlodowski,2930
+Asotin,State Treasurer,NA,Republican,Duane Davidson,4964
+Asotin,State Treasurer,NA,Republican,Michael Waite,3504
+Asotin,State Auditor,NA,Republican,Mark Miloscia,5693
+Asotin,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,3604
+Asotin,Attorney General,NA,Democratic,Bob Ferguson,4803
+Asotin,Attorney General,NA,Libertarian,Joshua B. Trumbull,4021
+Asotin,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,6131
+Asotin,Commissioner of Public Lands,NA,Democratic,Hilary Franz,3170
+Asotin,Superintendent of Public Instruction,NA,NA,Erin Jones,4075
+Asotin,Superintendent of Public Instruction,NA,NA,Chris Reykdal,3867
+Asotin,Insurance Commissioner,NA,Democratic,Mike Kreidler,3627
+Asotin,Insurance Commissioner,NA,Republican,Richard Schrock,5522
+Asotin,State Senator,9,G.O.P,Mark G. Schoesler,7459
+Asotin,State Representative,9-1,Republican,Mary Dye,6259
+Asotin,State Representative,9-1,Democratic,Jennifer Goulet,3164
+Asotin,State Representative,9-2,Republican,Joe Schmick,7642
+Benton,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,26360
+Benton,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,47194
+Benton,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,109
+Benton,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,70
+Benton,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,874
+Benton,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,601
+Benton,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,4819
+Benton,U.S. Senator,NA,Democratic,Patty Murray,35680
+Benton,U.S. Senator,NA,Republican,Chris Vance,46397
+Benton,U.S. Representative,4,Republican,Dan Newhouse,41782
+Benton,U.S. Representative,4,Republican,Clint Didier,36064
+Benton,Governor,NA,Democratic,Jay Inslee,31128
+Benton,Governor,NA,Republican,Bill Bryant,50730
+Benton,Lt. Governor,NA,Democratic,Cyrus Habib,26988
+Benton,Lt. Governor,NA,Republican,Marty McClendon,52203
+Benton,Secretary of State,NA,Republican,Kim Wyman,57340
+Benton,Secretary of State,NA,Democratic,Tina Podlodowski,21524
+Benton,State Treasurer,NA,Republican,Duane Davidson,50910
+Benton,State Treasurer,NA,Republican,Michael Waite,21754
+Benton,State Auditor,NA,Republican,Mark Miloscia,49957
+Benton,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,27675
+Benton,Attorney General,NA,Democratic,Bob Ferguson,41461
+Benton,Attorney General,NA,Libertarian,Joshua B. Trumbull,33618
+Benton,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,52916
+Benton,Commissioner of Public Lands,NA,Democratic,Hilary Franz,24734
+Benton,Superintendent of Public Instruction,NA,NA,Erin Jones,31308
+Benton,Superintendent of Public Instruction,NA,NA,Chris Reykdal,36390
+Benton,Insurance Commissioner,NA,Democratic,Mike Kreidler,30142
+Benton,Insurance Commissioner,NA,Republican,Richard Schrock,46296
+Benton,State Representative,8-1,Republican,Brad Klippert,33711
+Benton,State Representative,8-1,Republican,Rick Jansons,23750
+Benton,State Representative,8-2,Republican,Larry Haler,34579
+Benton,State Representative,8-2,Republican,Steve Simmons,23211
+Benton,State Senator,16,Republican,Maureen Walsh,13284
+Benton,State Representative,16-1,Democratic,Rebecca Francik,4508
+Benton,State Representative,16-1,Republican,William 'Bill' Jenkin,11175
+Benton,State Representative,16-2,Republican,Terry R. Nealey,11494
+Benton,State Representative,16-2,Democratic,Gary Downing,4122
+Chelan,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,13032
+Chelan,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,18114
+Chelan,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,43
+Chelan,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,29
+Chelan,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,480
+Chelan,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,178
+Chelan,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1504
+Chelan,U.S. Senator,NA,Democratic,Patty Murray,15586
+Chelan,U.S. Senator,NA,Republican,Chris Vance,18146
+Chelan,U.S. Representative,8,Republican,Dave Reichert,22411
+Chelan,U.S. Representative,8,Democratic,Tony Ventrella,10771
+Chelan,Governor,NA,Democratic,Jay Inslee,13866
+Chelan,Governor,NA,Republican,Bill Bryant,19934
+Chelan,Lt. Governor,NA,Democratic,Cyrus Habib,12451
+Chelan,Lt. Governor,NA,Republican,Marty McClendon,19997
+Chelan,Secretary of State,NA,Republican,Kim Wyman,22261
+Chelan,Secretary of State,NA,Democratic,Tina Podlodowski,10348
+Chelan,State Treasurer,NA,Republican,Duane Davidson,14996
+Chelan,State Treasurer,NA,Republican,Michael Waite,12755
+Chelan,State Auditor,NA,Republican,Mark Miloscia,19109
+Chelan,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,12285
+Chelan,Attorney General,NA,Democratic,Bob Ferguson,17507
+Chelan,Attorney General,NA,Libertarian,Joshua B. Trumbull,12244
+Chelan,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,20118
+Chelan,Commissioner of Public Lands,NA,Democratic,Hilary Franz,11780
+Chelan,Superintendent of Public Instruction,NA,NA,Erin Jones,12594
+Chelan,Superintendent of Public Instruction,NA,NA,Chris Reykdal,13848
+Chelan,Insurance Commissioner,NA,Democratic,Mike Kreidler,13562
+Chelan,Insurance Commissioner,NA,Republican,Richard Schrock,17608
+Chelan,State Senator,12,Republican,Brad Hawkins,16920
+Chelan,State Senator,12,Republican,Jon Wyss,13762
+Chelan,State Representative,12-1,Republican,Cary Condotta,20143
+Chelan,State Representative,12-1,Democratic,Dan Maher,12341
+Chelan,State Representative,12-2,Republican,Mike Steele,16895
+Chelan,State Representative,12-2,Republican,Jerry Paine,11337
+Clallam,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,17677
+Clallam,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,18794
+Clallam,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,50
+Clallam,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,32
+Clallam,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,810
+Clallam,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,256
+Clallam,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1838
+Clallam,U.S. Senator,NA,Democratic,Patty Murray,20549
+Clallam,U.S. Senator,NA,Republican,Chris Vance,18955
+Clallam,U.S. Representative,6,Democratic,Derek Kilmer,21557
+Clallam,U.S. Representative,6,Republican,Todd A. Bloom,17236
+Clallam,Governor,NA,Democratic,Jay Inslee,19354
+Clallam,Governor,NA,Republican,Bill Bryant,20108
+Clallam,Lt. Governor,NA,Democratic,Cyrus Habib,18184
+Clallam,Lt. Governor,NA,Republican,Marty McClendon,20140
+Clallam,Secretary of State,NA,Republican,Kim Wyman,22800
+Clallam,Secretary of State,NA,Democratic,Tina Podlodowski,15613
+Clallam,State Treasurer,NA,Republican,Duane Davidson,17688
+Clallam,State Treasurer,NA,Republican,Michael Waite,15268
+Clallam,State Auditor,NA,Republican,Mark Miloscia,19980
+Clallam,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,17493
+Clallam,Attorney General,NA,Democratic,Bob Ferguson,21809
+Clallam,Attorney General,NA,Libertarian,Joshua B. Trumbull,14346
+Clallam,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,20480
+Clallam,Commissioner of Public Lands,NA,Democratic,Hilary Franz,17198
+Clallam,Superintendent of Public Instruction,NA,NA,Erin Jones,15213
+Clallam,Superintendent of Public Instruction,NA,NA,Chris Reykdal,16182
+Clallam,Insurance Commissioner,NA,Democratic,Mike Kreidler,19364
+Clallam,Insurance Commissioner,NA,Republican,Richard Schrock,17726
+Clallam,State Senator,24,Democratic,Kevin Van De Wege,20266
+Clallam,State Senator,24,Independent GOP,Danille Turissini,17815
+Clallam,State Representative,24-1,Democratic,Mike Chapman,22278
+Clallam,State Representative,24-1,Republican,George Vrable,15880
+Clallam,State Representative,24-2,Democratic,Steve Tharinger,20148
+Clallam,State Representative,24-2,GOP/Independent,John D. Alger,17775
+Clark,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,92757
+Clark,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,92441
+Clark,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,239
+Clark,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,158
+Clark,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,3344
+Clark,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,1145
+Clark,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,10076
+Clark,U.S. Senator,NA,Democratic,Patty Murray,102922
+Clark,U.S. Senator,NA,Republican,Chris Vance,97637
+Clark,U.S. Representative,3,Republican,Jaime Herrera Beutler,117923
+Clark,U.S. Representative,3,Democratic,Jim Moeller,81385
+Clark,Governor,NA,Democratic,Jay Inslee,96032
+Clark,Governor,NA,Republican,Bill Bryant,103787
+Clark,Lt. Governor,NA,Democratic,Cyrus Habib,91829
+Clark,Lt. Governor,NA,Republican,Marty McClendon,102989
+Clark,Secretary of State,NA,Republican,Kim Wyman,118264
+Clark,Secretary of State,NA,Democratic,Tina Podlodowski,76361
+Clark,State Treasurer,NA,Republican,Duane Davidson,99385
+Clark,State Treasurer,NA,Republican,Michael Waite,73173
+Clark,State Auditor,NA,Republican,Mark Miloscia,101962
+Clark,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,89618
+Clark,Attorney General,NA,Democratic,Bob Ferguson,111601
+Clark,Attorney General,NA,Libertarian,Joshua B. Trumbull,72392
+Clark,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,99706
+Clark,Commissioner of Public Lands,NA,Democratic,Hilary Franz,91651
+Clark,Superintendent of Public Instruction,NA,NA,Erin Jones,81315
+Clark,Superintendent of Public Instruction,NA,NA,Chris Reykdal,79782
+Clark,Insurance Commissioner,NA,Democratic,Mike Kreidler,94558
+Clark,Insurance Commissioner,NA,Republican,Richard Schrock,93973
+Clark,State Senator,14,Republican,Curtis King,979
+Clark,State Senator,14,Independent GOP,Amanda Richards,758
+Clark,State Representative,14-1,Republican,Norm Johnson,1187
+Clark,State Representative,14-1,Democratic,Susan Soto Palmer,697
+Clark,State Representative,14-2,Republican,Gina McCabe,1251
+Clark,State Representative,14-2,Democratic,John (Eric) Adams,606
+Clark,State Senator,17,Republican,Lynda Wilson,32766
+Clark,State Senator,17,Independent Dem.,Tim Probst,26686
+Clark,State Representative,17-1,Republican,Vicki Kraft,30552
+Clark,State Representative,17-1,Independent Dem,Sam Kim,28585
+Clark,State Representative,17-2,Republican,Paul Harris,36936
+Clark,State Representative,17-2,Democratic,Martin Hash,21602
+Clark,State Senator,18,Republican,Ann Rivers,45316
+Clark,State Senator,18,Democratic,Eric K. Holt,25699
+Clark,State Representative,18-1,Republican,Brandon Vick,44729
+Clark,State Representative,18-1,Democratic,Justin Oberg,25874
+Clark,State Representative,18-2,Republican,Liz Pike,40354
+Clark,State Representative,18-2,Independent Dem.,Kathy Gillespie,30665
+Clark,State Senator,20,Republican,John Braun,4338
+Clark,State Representative,20-1,GOP,Richard DeBolt,4056
+Clark,State Representative,20-2,Republican,Ed Orcutt,4361
+Clark,State Senator,49,Democratic,Annette Cleveland,34548
+Clark,State Senator,49,Republican,Lewis Gerhardt,20943
+Clark,State Representative,49-1,Democratic,Sharon Wylie,34762
+Clark,State Representative,49-1,Democratic,Kaitlyn Beck,13381
+Clark,State Representative,49-2,Democratic,Monica Jurado Stonier,26745
+Clark,State Representative,49-2,Democratic,Alishia Topper,21756
+Columbia,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,526
+Columbia,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,1497
+Columbia,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,7
+Columbia,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,2
+Columbia,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,26
+Columbia,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,15
+Columbia,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,109
+Columbia,U.S. Senator,NA,Democratic,Patty Murray,854
+Columbia,U.S. Senator,NA,Republican,Chris Vance,1339
+Columbia,U.S. Representative,5,Republican,Cathy McMorris Rodgers,1638
+Columbia,U.S. Representative,5,Democratic,Joe Pakootas,556
+Columbia,Governor,NA,Democratic,Jay Inslee,688
+Columbia,Governor,NA,Republican,Bill Bryant,1491
+Columbia,Lt. Governor,NA,Democratic,Cyrus Habib,543
+Columbia,Lt. Governor,NA,Republican,Marty McClendon,1544
+Columbia,Secretary of State,NA,Republican,Kim Wyman,1654
+Columbia,Secretary of State,NA,Democratic,Tina Podlodowski,451
+Columbia,State Treasurer,NA,Republican,Duane Davidson,1251
+Columbia,State Treasurer,NA,Republican,Michael Waite,659
+Columbia,State Auditor,NA,Republican,Mark Miloscia,1439
+Columbia,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,616
+Columbia,Attorney General,NA,Democratic,Bob Ferguson,984
+Columbia,Attorney General,NA,Libertarian,Joshua B. Trumbull,951
+Columbia,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,1571
+Columbia,Commissioner of Public Lands,NA,Democratic,Hilary Franz,496
+Columbia,Superintendent of Public Instruction,NA,NA,Erin Jones,875
+Columbia,Superintendent of Public Instruction,NA,NA,Chris Reykdal,885
+Columbia,Insurance Commissioner,NA,Democratic,Mike Kreidler,622
+Columbia,Insurance Commissioner,NA,Republican,Richard Schrock,1378
+Columbia,State Senator,16,Republican,Maureen Walsh,1809
+Columbia,State Representative,16-1,Democratic,Rebecca Francik,546
+Columbia,State Representative,16-1,Republican,William 'Bill' Jenkin,1502
+Columbia,State Representative,16-2,Republican,Terry R. Nealey,1784
+Columbia,State Representative,16-2,Democratic,Gary Downing,371
+Cowlitz,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,17908
+Cowlitz,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,24185
+Cowlitz,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,84
+Cowlitz,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,58
+Cowlitz,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,787
+Cowlitz,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,327
+Cowlitz,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,2343
+Cowlitz,U.S. Senator,NA,Democratic,Patty Murray,22888
+Cowlitz,U.S. Senator,NA,Republican,Chris Vance,23031
+Cowlitz,U.S. Representative,3,Republican,Jaime Herrera Beutler,28932
+Cowlitz,U.S. Representative,3,Democratic,Jim Moeller,16568
+Cowlitz,Governor,NA,Democratic,Jay Inslee,19593
+Cowlitz,Governor,NA,Republican,Bill Bryant,26116
+Cowlitz,Lt. Governor,NA,Democratic,Cyrus Habib,18783
+Cowlitz,Lt. Governor,NA,Republican,Marty McClendon,25698
+Cowlitz,Secretary of State,NA,Republican,Kim Wyman,28206
+Cowlitz,Secretary of State,NA,Democratic,Tina Podlodowski,16397
+Cowlitz,State Treasurer,NA,Republican,Duane Davidson,20082
+Cowlitz,State Treasurer,NA,Republican,Michael Waite,18931
+Cowlitz,State Auditor,NA,Republican,Mark Miloscia,23522
+Cowlitz,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,19799
+Cowlitz,Attorney General,NA,Democratic,Bob Ferguson,24289
+Cowlitz,Attorney General,NA,Libertarian,Joshua B. Trumbull,17247
+Cowlitz,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,25418
+Cowlitz,Commissioner of Public Lands,NA,Democratic,Hilary Franz,18012
+Cowlitz,Superintendent of Public Instruction,NA,NA,Erin Jones,18209
+Cowlitz,Superintendent of Public Instruction,NA,NA,Chris Reykdal,18964
+Cowlitz,Insurance Commissioner,NA,Democratic,Mike Kreidler,20282
+Cowlitz,Insurance Commissioner,NA,Republican,Richard Schrock,22332
+Cowlitz,State Senator,19,Democratic,Dean Takko,15619
+Cowlitz,State Senator,19,Independent GOP,Sue Kuehl Pederson,12009
+Cowlitz,State Representative,19-1,Republican,Jim Walsh,13385
+Cowlitz,State Representative,19-1,Democratic,Teresa Purcell,14669
+Cowlitz,State Representative,19-2,Democratic,Brian E. Blake,16575
+Cowlitz,State Representative,19-2,Republican,Jimi O'Hagan,10880
+Cowlitz,State Senator,20,Republican,John Braun,12631
+Cowlitz,State Representative,20-1,GOP,Richard DeBolt,11895
+Cowlitz,State Representative,20-2,Republican,Ed Orcutt,12804
+Douglas,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,4918
+Douglas,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,9603
+Douglas,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,28
+Douglas,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,18
+Douglas,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,185
+Douglas,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,77
+Douglas,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,714
+Douglas,U.S. Senator,NA,Democratic,Patty Murray,6322
+Douglas,U.S. Senator,NA,Republican,Chris Vance,9333
+Douglas,U.S. Representative,4,Republican,Dan Newhouse,5105
+Douglas,U.S. Representative,4,Republican,Clint Didier,2896
+Douglas,U.S. Representative,8,Republican,Dave Reichert,4732
+Douglas,U.S. Representative,8,Democratic,Tony Ventrella,1944
+Douglas,Governor,NA,Democratic,Jay Inslee,5441
+Douglas,Governor,NA,Republican,Bill Bryant,10197
+Douglas,Lt. Governor,NA,Democratic,Cyrus Habib,4807
+Douglas,Lt. Governor,NA,Republican,Marty McClendon,10303
+Douglas,Secretary of State,NA,Republican,Kim Wyman,11232
+Douglas,Secretary of State,NA,Democratic,Tina Podlodowski,3962
+Douglas,State Treasurer,NA,Republican,Duane Davidson,7468
+Douglas,State Treasurer,NA,Republican,Michael Waite,5790
+Douglas,State Auditor,NA,Republican,Mark Miloscia,9821
+Douglas,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,4980
+Douglas,Attorney General,NA,Democratic,Bob Ferguson,7725
+Douglas,Attorney General,NA,Libertarian,Joshua B. Trumbull,6166
+Douglas,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,10471
+Douglas,Commissioner of Public Lands,NA,Democratic,Hilary Franz,4467
+Douglas,Superintendent of Public Instruction,NA,NA,Erin Jones,6090
+Douglas,Superintendent of Public Instruction,NA,NA,Chris Reykdal,6468
+Douglas,Insurance Commissioner,NA,Democratic,Mike Kreidler,5592
+Douglas,Insurance Commissioner,NA,Republican,Richard Schrock,9040
+Douglas,State Senator,12,Republican,Brad Hawkins,7897
+Douglas,State Senator,12,Republican,Jon Wyss,6730
+Douglas,State Representative,12-1,Republican,Cary Condotta,10242
+Douglas,State Representative,12-1,Democratic,Dan Maher,4963
+Douglas,State Representative,12-2,Republican,Mike Steele,7303
+Douglas,State Representative,12-2,Republican,Jerry Paine,6258
+Ferry,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,1098
+Ferry,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,2202
+Ferry,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,5
+Ferry,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,0
+Ferry,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,58
+Ferry,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,47
+Ferry,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,191
+Ferry,U.S. Senator,NA,Democratic,Patty Murray,1520
+Ferry,U.S. Senator,NA,Republican,Chris Vance,2099
+Ferry,U.S. Representative,5,Republican,Cathy McMorris Rodgers,2217
+Ferry,U.S. Representative,5,Democratic,Joe Pakootas,1416
+Ferry,Governor,NA,Democratic,Jay Inslee,1360
+Ferry,Governor,NA,Republican,Bill Bryant,2252
+Ferry,Lt. Governor,NA,Democratic,Cyrus Habib,1189
+Ferry,Lt. Governor,NA,Republican,Marty McClendon,2283
+Ferry,Secretary of State,NA,Republican,Kim Wyman,2395
+Ferry,Secretary of State,NA,Democratic,Tina Podlodowski,1066
+Ferry,State Treasurer,NA,Republican,Duane Davidson,1709
+Ferry,State Treasurer,NA,Republican,Michael Waite,1349
+Ferry,State Auditor,NA,Republican,Mark Miloscia,2172
+Ferry,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,1242
+Ferry,Attorney General,NA,Democratic,Bob Ferguson,1695
+Ferry,Attorney General,NA,Libertarian,Joshua B. Trumbull,1533
+Ferry,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,2364
+Ferry,Commissioner of Public Lands,NA,Democratic,Hilary Franz,1084
+Ferry,Superintendent of Public Instruction,NA,NA,Erin Jones,1312
+Ferry,Superintendent of Public Instruction,NA,NA,Chris Reykdal,1507
+Ferry,Insurance Commissioner,NA,Democratic,Mike Kreidler,1297
+Ferry,Insurance Commissioner,NA,Republican,Richard Schrock,2055
+Ferry,State Representative,7-1,Republican,Shelly Short,2924
+Ferry,State Representative,7-2,Republican,Joel Kretz,2574
+Ferry,State Representative,7-2,Libertarian,Mike Foster,800
+Franklin,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,8886
+Franklin,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,13206
+Franklin,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,46
+Franklin,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,34
+Franklin,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,225
+Franklin,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,175
+Franklin,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1148
+Franklin,U.S. Senator,NA,Democratic,Patty Murray,10766
+Franklin,U.S. Senator,NA,Republican,Chris Vance,13197
+Franklin,U.S. Representative,4,Republican,Dan Newhouse,11147
+Franklin,U.S. Representative,4,Republican,Clint Didier,11337
+Franklin,Governor,NA,Democratic,Jay Inslee,9731
+Franklin,Governor,NA,Republican,Bill Bryant,14387
+Franklin,Lt. Governor,NA,Democratic,Cyrus Habib,8721
+Franklin,Lt. Governor,NA,Republican,Marty McClendon,14732
+Franklin,Secretary of State,NA,Republican,Kim Wyman,15976
+Franklin,Secretary of State,NA,Democratic,Tina Podlodowski,7453
+Franklin,State Treasurer,NA,Republican,Duane Davidson,13253
+Franklin,State Treasurer,NA,Republican,Michael Waite,7535
+Franklin,State Auditor,NA,Republican,Mark Miloscia,14125
+Franklin,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,9011
+Franklin,Attorney General,NA,Democratic,Bob Ferguson,12544
+Franklin,Attorney General,NA,Libertarian,Joshua B. Trumbull,9795
+Franklin,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,15015
+Franklin,Commissioner of Public Lands,NA,Democratic,Hilary Franz,8196
+Franklin,Superintendent of Public Instruction,NA,NA,Erin Jones,10098
+Franklin,Superintendent of Public Instruction,NA,NA,Chris Reykdal,10122
+Franklin,Insurance Commissioner,NA,Democratic,Mike Kreidler,9491
+Franklin,Insurance Commissioner,NA,Republican,Richard Schrock,13288
+Franklin,State Senator,9,G.O.P,Mark G. Schoesler,13646
+Franklin,State Representative,9-1,Republican,Mary Dye,12068
+Franklin,State Representative,9-1,Democratic,Jennifer Goulet,4910
+Franklin,State Representative,9-2,Republican,Joe Schmick,13945
+Franklin,State Senator,16,Republican,Maureen Walsh,4712
+Franklin,State Representative,16-1,Democratic,Rebecca Francik,3607
+Franklin,State Representative,16-1,Republican,William 'Bill' Jenkin,2471
+Franklin,State Representative,16-2,Republican,Terry R. Nealey,2872
+Franklin,State Representative,16-2,Democratic,Gary Downing,3143
+Garfield,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,279
+Garfield,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,851
+Garfield,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,3
+Garfield,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,2
+Garfield,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,14
+Garfield,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,9
+Garfield,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,88
+Garfield,U.S. Senator,NA,Democratic,Patty Murray,486
+Garfield,U.S. Senator,NA,Republican,Chris Vance,771
+Garfield,U.S. Representative,5,Republican,Cathy McMorris Rodgers,973
+Garfield,U.S. Representative,5,Democratic,Joe Pakootas,295
+Garfield,Governor,NA,Democratic,Jay Inslee,370
+Garfield,Governor,NA,Republican,Bill Bryant,875
+Garfield,Lt. Governor,NA,Democratic,Cyrus Habib,296
+Garfield,Lt. Governor,NA,Republican,Marty McClendon,898
+Garfield,Secretary of State,NA,Republican,Kim Wyman,942
+Garfield,Secretary of State,NA,Democratic,Tina Podlodowski,252
+Garfield,State Treasurer,NA,Republican,Duane Davidson,618
+Garfield,State Treasurer,NA,Republican,Michael Waite,469
+Garfield,State Auditor,NA,Republican,Mark Miloscia,844
+Garfield,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,328
+Garfield,Attorney General,NA,Democratic,Bob Ferguson,585
+Garfield,Attorney General,NA,Libertarian,Joshua B. Trumbull,497
+Garfield,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,925
+Garfield,Commissioner of Public Lands,NA,Democratic,Hilary Franz,250
+Garfield,Superintendent of Public Instruction,NA,NA,Erin Jones,467
+Garfield,Superintendent of Public Instruction,NA,NA,Chris Reykdal,522
+Garfield,Insurance Commissioner,NA,Democratic,Mike Kreidler,365
+Garfield,Insurance Commissioner,NA,Republican,Richard Schrock,786
+Garfield,State Senator,9,G.O.P,Mark G. Schoesler,1013
+Garfield,State Representative,9-1,Republican,Mary Dye,941
+Garfield,State Representative,9-1,Democratic,Jennifer Goulet,308
+Garfield,State Representative,9-2,Republican,Joe Schmick,1051
+Grant,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,7810
+Grant,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,18518
+Grant,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,47
+Grant,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,45
+Grant,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,291
+Grant,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,248
+Grant,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1387
+Grant,U.S. Senator,NA,Democratic,Patty Murray,10329
+Grant,U.S. Senator,NA,Republican,Chris Vance,18404
+Grant,U.S. Representative,4,Republican,Dan Newhouse,15645
+Grant,U.S. Representative,4,Republican,Clint Didier,11148
+Grant,Governor,NA,Democratic,Jay Inslee,9242
+Grant,Governor,NA,Republican,Bill Bryant,19401
+Grant,Lt. Governor,NA,Democratic,Cyrus Habib,7882
+Grant,Lt. Governor,NA,Republican,Marty McClendon,19769
+Grant,Secretary of State,NA,Republican,Kim Wyman,20837
+Grant,Secretary of State,NA,Democratic,Tina Podlodowski,6792
+Grant,State Treasurer,NA,Republican,Duane Davidson,13285
+Grant,State Treasurer,NA,Republican,Michael Waite,11078
+Grant,State Auditor,NA,Republican,Mark Miloscia,18590
+Grant,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,8557
+Grant,Attorney General,NA,Democratic,Bob Ferguson,12879
+Grant,Attorney General,NA,Libertarian,Joshua B. Trumbull,12728
+Grant,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,19808
+Grant,Commissioner of Public Lands,NA,Democratic,Hilary Franz,7536
+Grant,Superintendent of Public Instruction,NA,NA,Erin Jones,11423
+Grant,Superintendent of Public Instruction,NA,NA,Chris Reykdal,12101
+Grant,Insurance Commissioner,NA,Democratic,Mike Kreidler,9021
+Grant,Insurance Commissioner,NA,Republican,Richard Schrock,17755
+Grant,State Senator,12,Republican,Brad Hawkins,1721
+Grant,State Senator,12,Republican,Jon Wyss,942
+Grant,State Representative,12-1,Republican,Cary Condotta,2016
+Grant,State Representative,12-1,Democratic,Dan Maher,865
+Grant,State Representative,12-2,Republican,Mike Steele,1673
+Grant,State Representative,12-2,Republican,Jerry Paine,777
+Grant,State Representative,13-1,Republican,Tom Dent,21004
+Grant,State Representative,13-2,Republican,Matt Manweller,17797
+Grant,State Representative,13-2,Democratic,Jordan Webb,6453
+Grays Harbor,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,12020
+Grays Harbor,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,14067
+Grays Harbor,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,53
+Grays Harbor,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,30
+Grays Harbor,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,568
+Grays Harbor,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,186
+Grays Harbor,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1443
+Grays Harbor,U.S. Senator,NA,Democratic,Patty Murray,15433
+Grays Harbor,U.S. Senator,NA,Republican,Chris Vance,13483
+Grays Harbor,U.S. Representative,6,Democratic,Derek Kilmer,16025
+Grays Harbor,U.S. Representative,6,Republican,Todd A. Bloom,12315
+Grays Harbor,Governor,NA,Democratic,Jay Inslee,14038
+Grays Harbor,Governor,NA,Republican,Bill Bryant,14843
+Grays Harbor,Lt. Governor,NA,Democratic,Cyrus Habib,13202
+Grays Harbor,Lt. Governor,NA,Republican,Marty McClendon,14748
+Grays Harbor,Secretary of State,NA,Republican,Kim Wyman,16881
+Grays Harbor,Secretary of State,NA,Democratic,Tina Podlodowski,11156
+Grays Harbor,State Treasurer,NA,Republican,Duane Davidson,12566
+Grays Harbor,State Treasurer,NA,Republican,Michael Waite,11714
+Grays Harbor,State Auditor,NA,Republican,Mark Miloscia,13660
+Grays Harbor,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,13455
+Grays Harbor,Attorney General,NA,Democratic,Bob Ferguson,16893
+Grays Harbor,Attorney General,NA,Libertarian,Joshua B. Trumbull,9646
+Grays Harbor,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,15255
+Grays Harbor,Commissioner of Public Lands,NA,Democratic,Hilary Franz,12215
+Grays Harbor,Superintendent of Public Instruction,NA,NA,Erin Jones,11225
+Grays Harbor,Superintendent of Public Instruction,NA,NA,Chris Reykdal,12407
+Grays Harbor,Insurance Commissioner,NA,Democratic,Mike Kreidler,14621
+Grays Harbor,Insurance Commissioner,NA,Republican,Richard Schrock,12392
+Grays Harbor,State Senator,19,Democratic,Dean Takko,6854
+Grays Harbor,State Senator,19,Independent GOP,Sue Kuehl Pederson,5820
+Grays Harbor,State Representative,19-1,Republican,Jim Walsh,6604
+Grays Harbor,State Representative,19-1,Democratic,Teresa Purcell,6352
+Grays Harbor,State Representative,19-2,Democratic,Brian E. Blake,8175
+Grays Harbor,State Representative,19-2,Republican,Jimi O'Hagan,4710
+Grays Harbor,State Senator,24,Democratic,Kevin Van De Wege,7532
+Grays Harbor,State Senator,24,Independent GOP,Danille Turissini,6874
+Grays Harbor,State Representative,24-1,Democratic,Mike Chapman,7881
+Grays Harbor,State Representative,24-1,Republican,George Vrable,6467
+Grays Harbor,State Representative,24-2,Democratic,Steve Tharinger,7255
+Grays Harbor,State Representative,24-2,GOP/Independent,John D. Alger,7021
+Island,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,20960
+Island,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,18465
+Island,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,48
+Island,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,39
+Island,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,807
+Island,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,238
+Island,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,2319
+Island,U.S. Senator,NA,Democratic,Patty Murray,23695
+Island,U.S. Senator,NA,Republican,Chris Vance,19761
+Island,U.S. Representative,2,Democratic,Rick Larsen,24864
+Island,U.S. Representative,2,Republican,Marc Hennemann,17901
+Island,Governor,NA,Democratic,Jay Inslee,21797
+Island,Governor,NA,Republican,Bill Bryant,21560
+Island,Lt. Governor,NA,Democratic,Cyrus Habib,21090
+Island,Lt. Governor,NA,Republican,Marty McClendon,20935
+Island,Secretary of State,NA,Republican,Kim Wyman,24494
+Island,Secretary of State,NA,Democratic,Tina Podlodowski,17613
+Island,State Treasurer,NA,Republican,Duane Davidson,20594
+Island,State Treasurer,NA,Republican,Michael Waite,16079
+Island,State Auditor,NA,Republican,Mark Miloscia,21395
+Island,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,19666
+Island,Attorney General,NA,Democratic,Bob Ferguson,25660
+Island,Attorney General,NA,Libertarian,Joshua B. Trumbull,14123
+Island,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,21145
+Island,Commissioner of Public Lands,NA,Democratic,Hilary Franz,20223
+Island,Superintendent of Public Instruction,NA,NA,Erin Jones,17673
+Island,Superintendent of Public Instruction,NA,NA,Chris Reykdal,17274
+Island,Insurance Commissioner,NA,Democratic,Mike Kreidler,22136
+Island,Insurance Commissioner,NA,Republican,Richard Schrock,18595
+Island,State Senator,10,Republican,Barbara Bailey,23151
+Island,State Senator,10,Democratic,Angie Homola,19391
+Island,State Representative,10-1,Republican,Norma Smith,27071
+Island,State Representative,10-1,Libertarian,Michael Scott,10262
+Island,State Representative,10-2,Republican,Dave Hayes,23538
+Island,State Representative,10-2,Democratic,Doris Brevoort,17718
+Jefferson,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,12656
+Jefferson,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,6037
+Jefferson,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,34
+Jefferson,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,22
+Jefferson,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,706
+Jefferson,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,75
+Jefferson,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,746
+Jefferson,U.S. Senator,NA,Democratic,Patty Murray,14098
+Jefferson,U.S. Senator,NA,Republican,Chris Vance,6408
+Jefferson,U.S. Representative,6,Democratic,Derek Kilmer,14110
+Jefferson,U.S. Representative,6,Republican,Todd A. Bloom,5972
+Jefferson,Governor,NA,Democratic,Jay Inslee,13399
+Jefferson,Governor,NA,Republican,Bill Bryant,7049
+Jefferson,Lt. Governor,NA,Democratic,Cyrus Habib,13065
+Jefferson,Lt. Governor,NA,Republican,Marty McClendon,6861
+Jefferson,Secretary of State,NA,Republican,Kim Wyman,8475
+Jefferson,Secretary of State,NA,Democratic,Tina Podlodowski,11495
+Jefferson,State Treasurer,NA,Republican,Duane Davidson,10305
+Jefferson,State Treasurer,NA,Republican,Michael Waite,6496
+Jefferson,State Auditor,NA,Republican,Mark Miloscia,7023
+Jefferson,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,12420
+Jefferson,Attorney General,NA,Democratic,Bob Ferguson,13919
+Jefferson,Attorney General,NA,Libertarian,Joshua B. Trumbull,5229
+Jefferson,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,7015
+Jefferson,Commissioner of Public Lands,NA,Democratic,Hilary Franz,12680
+Jefferson,Superintendent of Public Instruction,NA,NA,Erin Jones,7330
+Jefferson,Superintendent of Public Instruction,NA,NA,Chris Reykdal,9318
+Jefferson,Insurance Commissioner,NA,Democratic,Mike Kreidler,13204
+Jefferson,Insurance Commissioner,NA,Republican,Richard Schrock,6119
+Jefferson,State Senator,24,Democratic,Kevin Van De Wege,13010
+Jefferson,State Senator,24,Independent GOP,Danille Turissini,6653
+Jefferson,State Representative,24-1,Democratic,Mike Chapman,13688
+Jefferson,State Representative,24-1,Republican,George Vrable,5803
+Jefferson,State Representative,24-2,Democratic,Steve Tharinger,13301
+Jefferson,State Representative,24-2,GOP/Independent,John D. Alger,6099
+King,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,718322
+King,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,216339
+King,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,1109
+King,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,1072
+King,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,17704
+King,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,3092
+King,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,40861
+King,U.S. Senator,NA,Democratic,Patty Murray,728113
+King,U.S. Senator,NA,Republican,Chris Vance,273410
+King,U.S. Representative,1,Democratic,Suzan DelBene,90514
+King,U.S. Representative,1,Republican,Robert J. Sutherland,50098
+King,U.S. Representative,7,Democratic,Pramila Jayapal,200272
+King,U.S. Representative,7,Democratic,Brady Pinero Walkinshaw,154095
+King,U.S. Representative,8,Republican,Dave Reichert,105885
+King,U.S. Representative,8,Democratic,Tony Ventrella,82602
+King,U.S. Representative,9,Democratic,Adam Smith,198883
+King,U.S. Representative,9,Republican,Doug Basler,72263
+King,Governor,NA,Democratic,Jay Inslee,677943
+King,Governor,NA,Republican,Bill Bryant,321242
+King,Lt. Governor,NA,Democratic,Cyrus Habib,670754
+King,Lt. Governor,NA,Republican,Marty McClendon,285689
+King,Secretary of State,NA,Republican,Kim Wyman,396466
+King,Secretary of State,NA,Democratic,Tina Podlodowski,563438
+King,State Treasurer,NA,Republican,Duane Davidson,490359
+King,State Treasurer,NA,Republican,Michael Waite,317475
+King,State Auditor,NA,Republican,Mark Miloscia,337754
+King,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,591708
+King,Attorney General,NA,Democratic,Bob Ferguson,724608
+King,Attorney General,NA,Libertarian,Joshua B. Trumbull,200826
+King,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,287877
+King,Commissioner of Public Lands,NA,Democratic,Hilary Franz,648376
+King,Superintendent of Public Instruction,NA,NA,Erin Jones,391726
+King,Superintendent of Public Instruction,NA,NA,Chris Reykdal,421762
+King,Insurance Commissioner,NA,Democratic,Mike Kreidler,672924
+King,Insurance Commissioner,NA,Republican,Richard Schrock,248804
+King,State Senator,1,Republican,Mindie Wirth,8455
+King,State Senator,1,Democratic,Guy Palumbo,12755
+King,State Representative,1-1,Democratic,Derek Stanford,13516
+King,State Representative,1-1,Republican,Neil Thannisch,7448
+King,State Representative,1-2,Republican,Jim Langston,8568
+King,State Representative,1-2,Democratic,Shelley Kloba,12331
+King,State Senator,5,Democratic,Mark Mullet,37342
+King,State Senator,5,Republican,Chad Magendanz,36826
+King,State Representative,5-1,Republican,Jay Rodne,37772
+King,State Representative,5-1,Dem/Working Fmly,Jason Ritchie,34954
+King,State Representative,5-2,Republican,Paul Graves,39330
+King,State Representative,5-2,Democratic,Darcy Burner,33838
+King,State Senator,11,Democratic,Bob Hasegawa,38785
+King,State Senator,11,Libertarian,Dennis Price,12010
+King,State Representative,11-1,Democratic,Zack Hudgins,34801
+King,State Representative,11-1,Republican,Erin Smith Aboudara,16511
+King,State Representative,11-2,Democratic,Steve Bergquist,41507
+King,State Representative,30-1,Democratic,Mike Pellicciotti,25618
+King,State Representative,30-1,Republican,Linda Kochmar,21105
+King,State Representative,30-2,Democratic,Kristine Reeves,24073
+King,State Representative,30-2,Republican,Teri Hickel,22674
+King,State Representative,31-1,Republican,Drew Stokesbary,12669
+King,State Representative,31-1,Libertarian,John Frostad,5085
+King,State Representative,31-2,Republican,Phil Fortunato,10367
+King,State Representative,31-2,Independent Dem.,Lane Walthers,8309
+King,State Representative,32-1,Democratic,Cindy Ryu,29082
+King,State Representative,32-1,Republican,Alvin Rutledge,7191
+King,State Representative,32-2,Democratic,Ruth Kagi,28255
+King,State Representative,32-2,Republican,David D. Schirle,8073
+King,State Representative,33-1,Democratic,Tina L. Orwall,33312
+King,State Representative,33-1,Republican,John Potter,14257
+King,State Representative,33-2,Democratic,Mia Su-Ling Gregerson,30837
+King,State Representative,33-2,Republican,Pamela Pollock,16303
+King,State Representative,34-1,Democratic,Eileen L. Cody,58754
+King,State Representative,34-1,Republican,Matthew Benson,14126
+King,State Representative,34-2,Democratic,Joe Fitzgibbon,57954
+King,State Representative,34-2,Republican,Andrew Pilloud,14714
+King,State Senator,36,Democratic,Reuven Carlyle,72385
+King,State Representative,36-1,Democratic,Noel Christina Frame,71028
+King,State Representative,36-2,Democratic,Gael Tarleton,70492
+King,State Representative,37-1,Democratic,Sharon Tomiko Santos,57092
+King,State Representative,37-1,NA,John Dickinson,5709
+King,State Representative,37-2,Democratic,Eric Pettigrew,53597
+King,State Representative,37-2,NA,Tamra Smilanich,8406
+King,State Senator,39,Republican,Kirk Pearson,183
+King,State Representative,39-1,Republican,Dan Kristiansen,123
+King,State Representative,39-1,Democrat,Linda M. Wright,122
+King,State Representative,39-2,Republican,John Koster,107
+King,State Representative,39-2,Democratic,Ronda Metcalf,142
+King,State Senator,41,Democratic,Lisa Wellman,37107
+King,State Senator,41,Republican,Steve Litzow,34446
+King,State Representative,41-1,Democratic,Tana Senn,45092
+King,State Representative,41-1,Republican,John Pass,24818
+King,State Representative,41-2,Democratic,Judy Clibborn,43077
+King,State Representative,41-2,Republican,Michael Appleby,26794
+King,State Representative,43-1,Democratic,Nicole Macri,49605
+King,State Representative,43-1,Democratic,Dan Shih,26180
+King,State Representative,43-2,Democratic,Frank Chopp,67403
+King,State Representative,45-1,Democratic,Roger Goodman,42981
+King,State Representative,45-1,GOP,Ramiro Valderrama,26491
+King,State Representative,45-2,Democratic,Larry Springer,53018
+King,State Representative,46-1,Democratic,Gerry Pollet,63831
+King,State Representative,46-1,Libertarian,Stephanie Heart Viskovich,11371
+King,State Representative,46-2,Democratic,Jessyn Farrell,63887
+King,State Representative,47-1,Republican,Mark Hargrove,31327
+King,State Representative,47-1,Democratic,Brooke Valentine,23556
+King,State Representative,47-2,Democratic,Pat Sullivan,31858
+King,State Representative,47-2,Republican,Barry Knowles,23056
+King,State Representative,48-1,Democratic,Patty Kuderer,39472
+King,State Representative,48-1,Libertarian,Michelle Darnell,16824
+King,State Representative,48-2,Democratic,Joan McBride,40633
+King,State Representative,48-2,Libertarian,Benjamin Judah Phelps,15302
+Kitsap,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,63156
+Kitsap,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,49018
+Kitsap,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,165
+Kitsap,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,128
+Kitsap,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,2397
+Kitsap,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,857
+Kitsap,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,8596
+Kitsap,U.S. Senator,NA,Democratic,Patty Murray,71784
+Kitsap,U.S. Senator,NA,Republican,Chris Vance,54746
+Kitsap,U.S. Representative,6,Democratic,Derek Kilmer,74099
+Kitsap,U.S. Representative,6,Republican,Todd A. Bloom,47489
+Kitsap,Governor,NA,Democratic,Jay Inslee,66392
+Kitsap,Governor,NA,Republican,Bill Bryant,59762
+Kitsap,Lt. Governor,NA,Democratic,Cyrus Habib,63739
+Kitsap,Lt. Governor,NA,Republican,Marty McClendon,58842
+Kitsap,Secretary of State,NA,Republican,Kim Wyman,69426
+Kitsap,Secretary of State,NA,Democratic,Tina Podlodowski,53392
+Kitsap,State Treasurer,NA,Republican,Duane Davidson,56508
+Kitsap,State Treasurer,NA,Republican,Michael Waite,49511
+Kitsap,State Auditor,NA,Republican,Mark Miloscia,59223
+Kitsap,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,60572
+Kitsap,Attorney General,NA,Democratic,Bob Ferguson,75893
+Kitsap,Attorney General,NA,Libertarian,Joshua B. Trumbull,40324
+Kitsap,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,59070
+Kitsap,Commissioner of Public Lands,NA,Democratic,Hilary Franz,61344
+Kitsap,Superintendent of Public Instruction,NA,NA,Erin Jones,53014
+Kitsap,Superintendent of Public Instruction,NA,NA,Chris Reykdal,49673
+Kitsap,Insurance Commissioner,NA,Democratic,Mike Kreidler,67397
+Kitsap,Insurance Commissioner,NA,Republican,Richard Schrock,51657
+Kitsap,State Senator,23,Democratic,Christine Rolfes,51541
+Kitsap,State Representative,23-1,Democratic,Sherry V. Appleton,39457
+Kitsap,State Representative,23-1,Republican,Loretta Byrnes,29491
+Kitsap,State Representative,23-2,Democratic,Drew Hansen,50973
+Kitsap,State Representative,26-1,Republican,Jesse L. Young,19033
+Kitsap,State Representative,26-1,Independent Democrat,Larry Seaquist,14866
+Kitsap,State Representative,26-2,Republican,Michelle Caldier,19250
+Kitsap,State Representative,26-2,Independent Dem.,Randy Spitzer,14488
+Kitsap,State Representative,35-1,Republican,Dan Griffey,10049
+Kitsap,State Representative,35-1,Independent Dem.,Irene Bowling,7889
+Kitsap,State Representative,35-2,Republican,Drew C. MacEwen,10083
+Kitsap,State Representative,35-2,Independent Dem.,Craig Patti,7745
+Kittitas,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,7489
+Kittitas,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,10100
+Kittitas,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,29
+Kittitas,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,19
+Kittitas,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,315
+Kittitas,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,95
+Kittitas,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,908
+Kittitas,U.S. Senator,NA,Democratic,Patty Murray,8830
+Kittitas,U.S. Senator,NA,Republican,Chris Vance,10292
+Kittitas,U.S. Representative,8,Republican,Dave Reichert,12048
+Kittitas,U.S. Representative,8,Democratic,Tony Ventrella,6657
+Kittitas,Governor,NA,Democratic,Jay Inslee,7984
+Kittitas,Governor,NA,Republican,Bill Bryant,11139
+Kittitas,Lt. Governor,NA,Democratic,Cyrus Habib,7249
+Kittitas,Lt. Governor,NA,Republican,Marty McClendon,11012
+Kittitas,Secretary of State,NA,Republican,Kim Wyman,12298
+Kittitas,Secretary of State,NA,Democratic,Tina Podlodowski,6129
+Kittitas,State Treasurer,NA,Republican,Duane Davidson,9635
+Kittitas,State Treasurer,NA,Republican,Michael Waite,6219
+Kittitas,State Auditor,NA,Republican,Mark Miloscia,10717
+Kittitas,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,7139
+Kittitas,Attorney General,NA,Democratic,Bob Ferguson,10209
+Kittitas,Attorney General,NA,Libertarian,Joshua B. Trumbull,6707
+Kittitas,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,11333
+Kittitas,Commissioner of Public Lands,NA,Democratic,Hilary Franz,6822
+Kittitas,Superintendent of Public Instruction,NA,NA,Erin Jones,6801
+Kittitas,Superintendent of Public Instruction,NA,NA,Chris Reykdal,7910
+Kittitas,Insurance Commissioner,NA,Democratic,Mike Kreidler,7901
+Kittitas,Insurance Commissioner,NA,Republican,Richard Schrock,9688
+Kittitas,State Representative,13-1,Republican,Tom Dent,14162
+Kittitas,State Representative,13-2,Republican,Matt Manweller,11541
+Kittitas,State Representative,13-2,Democratic,Jordan Webb,6543
+Klickitat,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,4194
+Klickitat,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,5789
+Klickitat,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,19
+Klickitat,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,12
+Klickitat,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,217
+Klickitat,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,75
+Klickitat,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,463
+Klickitat,U.S. Senator,NA,Democratic,Patty Murray,5121
+Klickitat,U.S. Senator,NA,Republican,Chris Vance,5692
+Klickitat,U.S. Representative,3,Republican,Jaime Herrera Beutler,6678
+Klickitat,U.S. Representative,3,Democratic,Jim Moeller,3891
+Klickitat,Governor,NA,Democratic,Jay Inslee,4517
+Klickitat,Governor,NA,Republican,Bill Bryant,6260
+Klickitat,Lt. Governor,NA,Democratic,Cyrus Habib,4332
+Klickitat,Lt. Governor,NA,Republican,Marty McClendon,6109
+Klickitat,Secretary of State,NA,Republican,Kim Wyman,6593
+Klickitat,Secretary of State,NA,Democratic,Tina Podlodowski,3833
+Klickitat,State Treasurer,NA,Republican,Duane Davidson,5443
+Klickitat,State Treasurer,NA,Republican,Michael Waite,3629
+Klickitat,State Auditor,NA,Republican,Mark Miloscia,5914
+Klickitat,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,4354
+Klickitat,Attorney General,NA,Democratic,Bob Ferguson,5436
+Klickitat,Attorney General,NA,Libertarian,Joshua B. Trumbull,4211
+Klickitat,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,6196
+Klickitat,Commissioner of Public Lands,NA,Democratic,Hilary Franz,4126
+Klickitat,Superintendent of Public Instruction,NA,NA,Erin Jones,4270
+Klickitat,Superintendent of Public Instruction,NA,NA,Chris Reykdal,4167
+Klickitat,Insurance Commissioner,NA,Democratic,Mike Kreidler,4431
+Klickitat,Insurance Commissioner,NA,Republican,Richard Schrock,5597
+Klickitat,State Senator,14,Republican,Curtis King,5022
+Klickitat,State Senator,14,Independent GOP,Amanda Richards,4298
+Klickitat,State Representative,14-1,Republican,Norm Johnson,6557
+Klickitat,State Representative,14-1,Democratic,Susan Soto Palmer,3774
+Klickitat,State Representative,14-2,Republican,Gina McCabe,6980
+Klickitat,State Representative,14-2,Democratic,John (Eric) Adams,3370
+Lewis,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,9654
+Lewis,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,21992
+Lewis,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,63
+Lewis,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,33
+Lewis,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,514
+Lewis,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,229
+Lewis,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1664
+Lewis,U.S. Senator,NA,Democratic,Patty Murray,13266
+Lewis,U.S. Senator,NA,Republican,Chris Vance,21319
+Lewis,U.S. Representative,3,Republican,Jaime Herrera Beutler,25095
+Lewis,U.S. Representative,3,Democratic,Jim Moeller,8824
+Lewis,Governor,NA,Democratic,Jay Inslee,11163
+Lewis,Governor,NA,Republican,Bill Bryant,23539
+Lewis,Lt. Governor,NA,Democratic,Cyrus Habib,10473
+Lewis,Lt. Governor,NA,Republican,Marty McClendon,23077
+Lewis,Secretary of State,NA,Republican,Kim Wyman,25134
+Lewis,Secretary of State,NA,Democratic,Tina Podlodowski,8694
+Lewis,State Treasurer,NA,Republican,Duane Davidson,16200
+Lewis,State Treasurer,NA,Republican,Michael Waite,13404
+Lewis,State Auditor,NA,Republican,Mark Miloscia,21896
+Lewis,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,10813
+Lewis,Attorney General,NA,Democratic,Bob Ferguson,16418
+Lewis,Attorney General,NA,Libertarian,Joshua B. Trumbull,14646
+Lewis,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,23545
+Lewis,Commissioner of Public Lands,NA,Democratic,Hilary Franz,9564
+Lewis,Superintendent of Public Instruction,NA,NA,Erin Jones,13389
+Lewis,Superintendent of Public Instruction,NA,NA,Chris Reykdal,14797
+Lewis,Insurance Commissioner,NA,Democratic,Mike Kreidler,12134
+Lewis,Insurance Commissioner,NA,Republican,Richard Schrock,20123
+Lewis,State Senator,19,Democratic,Dean Takko,1105
+Lewis,State Senator,19,Independent GOP,Sue Kuehl Pederson,1976
+Lewis,State Representative,19-1,Republican,Jim Walsh,2324
+Lewis,State Representative,19-1,Democratic,Teresa Purcell,896
+Lewis,State Representative,19-2,Democratic,Brian E. Blake,1202
+Lewis,State Representative,19-2,Republican,Jimi O'Hagan,1968
+Lewis,State Senator,20,Republican,John Braun,24394
+Lewis,State Representative,20-1,GOP,Richard DeBolt,23057
+Lewis,State Representative,20-2,Republican,Ed Orcutt,23545
+Lincoln,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,1244
+Lincoln,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,4108
+Lincoln,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,11
+Lincoln,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,5
+Lincoln,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,50
+Lincoln,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,43
+Lincoln,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,252
+Lincoln,U.S. Senator,NA,Democratic,Patty Murray,1943
+Lincoln,U.S. Senator,NA,Republican,Chris Vance,3837
+Lincoln,U.S. Representative,5,Republican,Cathy McMorris Rodgers,4261
+Lincoln,U.S. Representative,5,Democratic,Joe Pakootas,1496
+Lincoln,Governor,NA,Democratic,Jay Inslee,1616
+Lincoln,Governor,NA,Republican,Bill Bryant,4160
+Lincoln,Lt. Governor,NA,Democratic,Cyrus Habib,1267
+Lincoln,Lt. Governor,NA,Republican,Marty McClendon,4305
+Lincoln,Secretary of State,NA,Republican,Kim Wyman,4492
+Lincoln,Secretary of State,NA,Democratic,Tina Podlodowski,1080
+Lincoln,State Treasurer,NA,Republican,Duane Davidson,3021
+Lincoln,State Treasurer,NA,Republican,Michael Waite,2052
+Lincoln,State Auditor,NA,Republican,Mark Miloscia,4050
+Lincoln,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,1422
+Lincoln,Attorney General,NA,Democratic,Bob Ferguson,2396
+Lincoln,Attorney General,NA,Libertarian,Joshua B. Trumbull,2674
+Lincoln,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,4417
+Lincoln,Commissioner of Public Lands,NA,Democratic,Hilary Franz,1117
+Lincoln,Superintendent of Public Instruction,NA,NA,Erin Jones,2091
+Lincoln,Superintendent of Public Instruction,NA,NA,Chris Reykdal,2530
+Lincoln,Insurance Commissioner,NA,Democratic,Mike Kreidler,1601
+Lincoln,Insurance Commissioner,NA,Republican,Richard Schrock,3830
+Lincoln,State Representative,13-1,Republican,Tom Dent,4954
+Lincoln,State Representative,13-2,Republican,Matt Manweller,4350
+Lincoln,State Representative,13-2,Democratic,Jordan Webb,1132
+Mason,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,11993
+Mason,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,13677
+Mason,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,40
+Mason,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,36
+Mason,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,556
+Mason,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,211
+Mason,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1560
+Mason,U.S. Senator,NA,Democratic,Patty Murray,14848
+Mason,U.S. Senator,NA,Republican,Chris Vance,13677
+Mason,U.S. Representative,6,Democratic,Derek Kilmer,11189
+Mason,U.S. Representative,6,Republican,Todd A. Bloom,10224
+Mason,U.S. Representative,10,Democratic,Denny Heck,3749
+Mason,U.S. Representative,10,Republican,Jim Postma,2677
+Mason,Governor,NA,Democratic,Jay Inslee,13126
+Mason,Governor,NA,Republican,Bill Bryant,15365
+Mason,Lt. Governor,NA,Democratic,Cyrus Habib,12489
+Mason,Lt. Governor,NA,Republican,Marty McClendon,15123
+Mason,Secretary of State,NA,Republican,Kim Wyman,17295
+Mason,Secretary of State,NA,Democratic,Tina Podlodowski,10426
+Mason,State Treasurer,NA,Republican,Duane Davidson,12058
+Mason,State Treasurer,NA,Republican,Michael Waite,11684
+Mason,State Auditor,NA,Republican,Mark Miloscia,14284
+Mason,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,12661
+Mason,Attorney General,NA,Democratic,Bob Ferguson,16174
+Mason,Attorney General,NA,Libertarian,Joshua B. Trumbull,9957
+Mason,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,15e3
+Mason,Commissioner of Public Lands,NA,Democratic,Hilary Franz,12015
+Mason,Superintendent of Public Instruction,NA,NA,Erin Jones,10904
+Mason,Superintendent of Public Instruction,NA,NA,Chris Reykdal,11937
+Mason,Insurance Commissioner,NA,Democratic,Mike Kreidler,13984
+Mason,Insurance Commissioner,NA,Republican,Richard Schrock,12688
+Mason,State Representative,35-1,Republican,Dan Griffey,15195
+Mason,State Representative,35-1,Independent Dem.,Irene Bowling,12080
+Mason,State Representative,35-2,Republican,Drew C. MacEwen,14902
+Mason,State Representative,35-2,Independent Dem.,Craig Patti,12042
+Okanogan,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,6298
+Okanogan,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,9610
+Okanogan,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,21
+Okanogan,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,19
+Okanogan,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,291
+Okanogan,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,139
+Okanogan,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,713
+Okanogan,U.S. Senator,NA,Democratic,Patty Murray,8095
+Okanogan,U.S. Senator,NA,Republican,Chris Vance,9160
+Okanogan,U.S. Representative,4,Republican,Dan Newhouse,10567
+Okanogan,U.S. Representative,4,Republican,Clint Didier,4822
+Okanogan,Governor,NA,Democratic,Jay Inslee,7437
+Okanogan,Governor,NA,Republican,Bill Bryant,9794
+Okanogan,Lt. Governor,NA,Democratic,Cyrus Habib,6483
+Okanogan,Lt. Governor,NA,Republican,Marty McClendon,10107
+Okanogan,Secretary of State,NA,Republican,Kim Wyman,10788
+Okanogan,Secretary of State,NA,Democratic,Tina Podlodowski,5772
+Okanogan,State Treasurer,NA,Republican,Duane Davidson,7874
+Okanogan,State Treasurer,NA,Republican,Michael Waite,6389
+Okanogan,State Auditor,NA,Republican,Mark Miloscia,9540
+Okanogan,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,6761
+Okanogan,Attorney General,NA,Democratic,Bob Ferguson,8799
+Okanogan,Attorney General,NA,Libertarian,Joshua B. Trumbull,6726
+Okanogan,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,10481
+Okanogan,Commissioner of Public Lands,NA,Democratic,Hilary Franz,6064
+Okanogan,Superintendent of Public Instruction,NA,NA,Erin Jones,6822
+Okanogan,Superintendent of Public Instruction,NA,NA,Chris Reykdal,7118
+Okanogan,Insurance Commissioner,NA,Democratic,Mike Kreidler,7020
+Okanogan,Insurance Commissioner,NA,Republican,Richard Schrock,9084
+Okanogan,State Representative,7-1,Republican,Shelly Short,6935
+Okanogan,State Representative,7-2,Republican,Joel Kretz,6542
+Okanogan,State Representative,7-2,Libertarian,Mike Foster,1861
+Okanogan,State Senator,12,Republican,Brad Hawkins,4344
+Okanogan,State Senator,12,Republican,Jon Wyss,2824
+Okanogan,State Representative,12-1,Republican,Cary Condotta,4347
+Okanogan,State Representative,12-1,Democratic,Dan Maher,3484
+Okanogan,State Representative,12-2,Republican,Mike Steele,4526
+Okanogan,State Representative,12-2,Republican,Jerry Paine,1740
+Pacific,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,4620
+Pacific,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,5360
+Pacific,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,22
+Pacific,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,17
+Pacific,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,200
+Pacific,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,61
+Pacific,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,436
+Pacific,U.S. Senator,NA,Democratic,Patty Murray,5951
+Pacific,U.S. Senator,NA,Republican,Chris Vance,4819
+Pacific,U.S. Representative,3,Republican,Jaime Herrera Beutler,6280
+Pacific,U.S. Representative,3,Democratic,Jim Moeller,4310
+Pacific,Governor,NA,Democratic,Jay Inslee,5313
+Pacific,Governor,NA,Republican,Bill Bryant,5428
+Pacific,Lt. Governor,NA,Democratic,Cyrus Habib,4950
+Pacific,Lt. Governor,NA,Republican,Marty McClendon,5385
+Pacific,Secretary of State,NA,Republican,Kim Wyman,6027
+Pacific,Secretary of State,NA,Democratic,Tina Podlodowski,4316
+Pacific,State Treasurer,NA,Republican,Duane Davidson,4744
+Pacific,State Treasurer,NA,Republican,Michael Waite,4032
+Pacific,State Auditor,NA,Republican,Mark Miloscia,5147
+Pacific,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,4904
+Pacific,Attorney General,NA,Democratic,Bob Ferguson,6188
+Pacific,Attorney General,NA,Libertarian,Joshua B. Trumbull,3525
+Pacific,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,5589
+Pacific,Commissioner of Public Lands,NA,Democratic,Hilary Franz,4576
+Pacific,Superintendent of Public Instruction,NA,NA,Erin Jones,4189
+Pacific,Superintendent of Public Instruction,NA,NA,Chris Reykdal,4271
+Pacific,Insurance Commissioner,NA,Democratic,Mike Kreidler,5261
+Pacific,Insurance Commissioner,NA,Republican,Richard Schrock,4713
+Pacific,State Senator,19,Democratic,Dean Takko,5971
+Pacific,State Senator,19,Independent GOP,Sue Kuehl Pederson,4267
+Pacific,State Representative,19-1,Republican,Jim Walsh,5130
+Pacific,State Representative,19-1,Democratic,Teresa Purcell,5197
+Pacific,State Representative,19-2,Democratic,Brian E. Blake,6366
+Pacific,State Representative,19-2,Republican,Jimi O'Hagan,3982
+Pend Oreille,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,1934
+Pend Oreille,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,4373
+Pend Oreille,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,10
+Pend Oreille,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,9
+Pend Oreille,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,99
+Pend Oreille,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,54
+Pend Oreille,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,323
+Pend Oreille,U.S. Senator,NA,Democratic,Patty Murray,2775
+Pend Oreille,U.S. Senator,NA,Republican,Chris Vance,4093
+Pend Oreille,U.S. Representative,5,Republican,Cathy McMorris Rodgers,4405
+Pend Oreille,U.S. Representative,5,Democratic,Joe Pakootas,2449
+Pend Oreille,Governor,NA,Democratic,Jay Inslee,2520
+Pend Oreille,Governor,NA,Republican,Bill Bryant,4364
+Pend Oreille,Lt. Governor,NA,Democratic,Cyrus Habib,2161
+Pend Oreille,Lt. Governor,NA,Republican,Marty McClendon,4473
+Pend Oreille,Secretary of State,NA,Republican,Kim Wyman,4715
+Pend Oreille,Secretary of State,NA,Democratic,Tina Podlodowski,1890
+Pend Oreille,State Treasurer,NA,Republican,Duane Davidson,3413
+Pend Oreille,State Treasurer,NA,Republican,Michael Waite,2452
+Pend Oreille,State Auditor,NA,Republican,Mark Miloscia,4230
+Pend Oreille,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,2295
+Pend Oreille,Attorney General,NA,Democratic,Bob Ferguson,3121
+Pend Oreille,Attorney General,NA,Libertarian,Joshua B. Trumbull,3109
+Pend Oreille,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,4659
+Pend Oreille,Commissioner of Public Lands,NA,Democratic,Hilary Franz,1958
+Pend Oreille,Superintendent of Public Instruction,NA,NA,Erin Jones,2702
+Pend Oreille,Superintendent of Public Instruction,NA,NA,Chris Reykdal,2910
+Pend Oreille,Insurance Commissioner,NA,Democratic,Mike Kreidler,2380
+Pend Oreille,Insurance Commissioner,NA,Republican,Richard Schrock,4062
+Pend Oreille,State Representative,7-1,Republican,Shelly Short,5341
+Pend Oreille,State Representative,7-2,Republican,Joel Kretz,4587
+Pend Oreille,State Representative,7-2,Libertarian,Mike Foster,1501
+Pierce,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,172538
+Pierce,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,146824
+Pierce,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,539
+Pierce,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,410
+Pierce,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,6144
+Pierce,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,2121
+Pierce,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,19909
+Pierce,U.S. Senator,NA,Democratic,Patty Murray,196171
+Pierce,U.S. Senator,NA,Republican,Chris Vance,157644
+Pierce,U.S. Representative,6,Democratic,Derek Kilmer,64738
+Pierce,U.S. Representative,6,Republican,Todd A. Bloom,32880
+Pierce,U.S. Representative,8,Republican,Dave Reichert,48069
+Pierce,U.S. Representative,8,Democratic,Tony Ventrella,25746
+Pierce,U.S. Representative,9,Democratic,Adam Smith,6282
+Pierce,U.S. Representative,9,Republican,Doug Basler,4054
+Pierce,U.S. Representative,10,Democratic,Denny Heck,90107
+Pierce,U.S. Representative,10,Republican,Jim Postma,71828
+Pierce,Governor,NA,Democratic,Jay Inslee,176825
+Pierce,Governor,NA,Republican,Bill Bryant,176287
+Pierce,Lt. Governor,NA,Democratic,Cyrus Habib,171252
+Pierce,Lt. Governor,NA,Republican,Marty McClendon,170097
+Pierce,Secretary of State,NA,Republican,Kim Wyman,200835
+Pierce,Secretary of State,NA,Democratic,Tina Podlodowski,140962
+Pierce,State Treasurer,NA,Republican,Duane Davidson,168096
+Pierce,State Treasurer,NA,Republican,Michael Waite,130576
+Pierce,State Auditor,NA,Republican,Mark Miloscia,164971
+Pierce,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,171823
+Pierce,Attorney General,NA,Democratic,Bob Ferguson,208334
+Pierce,Attorney General,NA,Libertarian,Joshua B. Trumbull,116240
+Pierce,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,169007
+Pierce,Commissioner of Public Lands,NA,Democratic,Hilary Franz,164672
+Pierce,Superintendent of Public Instruction,NA,NA,Erin Jones,150877
+Pierce,Superintendent of Public Instruction,NA,NA,Chris Reykdal,137025
+Pierce,Insurance Commissioner,NA,Democratic,Mike Kreidler,184148
+Pierce,Insurance Commissioner,NA,Republican,Richard Schrock,146390
+Pierce,State Senator,2,Republican,Randi Becker,24157
+Pierce,State Senator,2,Democratic,Marilyn Rasmussen,13691
+Pierce,State Representative,2-1,Republican,Andrew Barkis,22154
+Pierce,State Representative,2-1,Independent Dem.,Amy Pivetta Hoffman,14868
+Pierce,State Representative,2-2,Republican,JT Wilcox,25474
+Pierce,State Representative,2-2,Democratic,Derek Maynes,11972
+Pierce,State Senator,25,Republican,Hans Zeiger,35138
+Pierce,State Senator,25,Democratic,Karl Mecklenburg,24088
+Pierce,State Representative,25-1,Republican,Melanie Stambaugh,34719
+Pierce,State Representative,25-1,Democratic,Jamie Smith,24549
+Pierce,State Representative,25-2,Republican,Joyce McDonald,33101
+Pierce,State Representative,25-2,Democratic,Michelle Chatterton,25804
+Pierce,State Representative,26-1,Republican,Jesse L. Young,20824
+Pierce,State Representative,26-1,Independent Democrat,Larry Seaquist,15358
+Pierce,State Representative,26-2,Republican,Michelle Caldier,21505
+Pierce,State Representative,26-2,Independent Dem.,Randy Spitzer,13899
+Pierce,State Senator,27,Democratic,Jeannie Darneille,40241
+Pierce,State Senator,27,Republican,Greg Taylor,17859
+Pierce,State Representative,27-1,Democratic,Laurie Jinkins,46263
+Pierce,State Representative,27-2,Democratic,Jake Fey,46153
+Pierce,State Senator,28,Republican,Steve O'Ban,30139
+Pierce,State Senator,28,Democratic,Marisa Peloquin,26835
+Pierce,State Representative,28-1,Republican,Richard (Dick) Muri,29503
+Pierce,State Representative,28-1,Democratic,Mari Leavitt,27128
+Pierce,State Representative,28-2,Democratic,Christine Kilduff,30920
+Pierce,State Representative,28-2,Republican,Paul Wagemann,25582
+Pierce,State Representative,29-1,Democratic,David Sawyer,24234
+Pierce,State Representative,29-1,Independent Rep,Rick Thomas,16646
+Pierce,State Representative,29-2,Democratic,Steve Kirby,25318
+Pierce,State Representative,29-2,Republican,Jessica Garcia,16334
+Pierce,State Representative,30-1,Democratic,Mike Pellicciotti,1202
+Pierce,State Representative,30-1,Republican,Linda Kochmar,1360
+Pierce,State Representative,30-2,Democratic,Kristine Reeves,1133
+Pierce,State Representative,30-2,Republican,Teri Hickel,1450
+Pierce,State Representative,31-1,Republican,Drew Stokesbary,30107
+Pierce,State Representative,31-1,Libertarian,John Frostad,11891
+Pierce,State Representative,31-2,Republican,Phil Fortunato,25633
+Pierce,State Representative,31-2,Independent Dem.,Lane Walthers,18055
+San Juan,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,7172
+San Juan,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,2688
+San Juan,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,11
+San Juan,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,11
+San Juan,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,467
+San Juan,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,23
+San Juan,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,402
+San Juan,U.S. Senator,NA,Democratic,Patty Murray,7789
+San Juan,U.S. Senator,NA,Republican,Chris Vance,3091
+San Juan,U.S. Representative,2,Democratic,Rick Larsen,7769
+San Juan,U.S. Representative,2,Republican,Marc Hennemann,2946
+San Juan,Governor,NA,Democratic,Jay Inslee,7509
+San Juan,Governor,NA,Republican,Bill Bryant,3356
+San Juan,Lt. Governor,NA,Democratic,Cyrus Habib,7398
+San Juan,Lt. Governor,NA,Republican,Marty McClendon,3179
+San Juan,Secretary of State,NA,Republican,Kim Wyman,4044
+San Juan,Secretary of State,NA,Democratic,Tina Podlodowski,6516
+San Juan,State Treasurer,NA,Republican,Duane Davidson,4583
+San Juan,State Treasurer,NA,Republican,Michael Waite,3506
+San Juan,State Auditor,NA,Republican,Mark Miloscia,3388
+San Juan,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,6821
+San Juan,Attorney General,NA,Democratic,Bob Ferguson,7393
+San Juan,Attorney General,NA,Libertarian,Joshua B. Trumbull,2614
+San Juan,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,3255
+San Juan,Commissioner of Public Lands,NA,Democratic,Hilary Franz,7075
+San Juan,Superintendent of Public Instruction,NA,NA,Erin Jones,5052
+San Juan,Superintendent of Public Instruction,NA,NA,Chris Reykdal,3553
+San Juan,Insurance Commissioner,NA,Democratic,Mike Kreidler,7085
+San Juan,Insurance Commissioner,NA,Republican,Richard Schrock,3033
+San Juan,State Senator,40,Democratic,Kevin Ranker,7738
+San Juan,State Senator,40,Republican,Daniel R. Miller,2714
+San Juan,State Representative,40-1,Democratic,Kristine Lytton,7702
+San Juan,State Representative,40-2,Democratic,Jeff Morris,7619
+Skagit,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,26690
+Skagit,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,24736
+Skagit,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,73
+Skagit,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,68
+Skagit,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,1006
+Skagit,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,305
+Skagit,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,3090
+Skagit,U.S. Senator,NA,Democratic,Patty Murray,30572
+Skagit,U.S. Senator,NA,Republican,Chris Vance,26600
+Skagit,U.S. Representative,1,Democratic,Suzan DelBene,11119
+Skagit,U.S. Representative,1,Republican,Robert J. Sutherland,10011
+Skagit,U.S. Representative,2,Democratic,Rick Larsen,19743
+Skagit,U.S. Representative,2,Republican,Marc Hennemann,15084
+Skagit,Governor,NA,Democratic,Jay Inslee,28273
+Skagit,Governor,NA,Republican,Bill Bryant,28701
+Skagit,Lt. Governor,NA,Democratic,Cyrus Habib,27001
+Skagit,Lt. Governor,NA,Republican,Marty McClendon,27803
+Skagit,Secretary of State,NA,Republican,Kim Wyman,32714
+Skagit,Secretary of State,NA,Democratic,Tina Podlodowski,22457
+Skagit,State Treasurer,NA,Republican,Duane Davidson,24920
+Skagit,State Treasurer,NA,Republican,Michael Waite,22262
+Skagit,State Auditor,NA,Republican,Mark Miloscia,28119
+Skagit,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,25433
+Skagit,Attorney General,NA,Democratic,Bob Ferguson,32906
+Skagit,Attorney General,NA,Libertarian,Joshua B. Trumbull,18615
+Skagit,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,28667
+Skagit,Commissioner of Public Lands,NA,Democratic,Hilary Franz,25529
+Skagit,Superintendent of Public Instruction,NA,NA,Erin Jones,21988
+Skagit,Superintendent of Public Instruction,NA,NA,Chris Reykdal,23290
+Skagit,Insurance Commissioner,NA,Democratic,Mike Kreidler,28230
+Skagit,Insurance Commissioner,NA,Republican,Richard Schrock,24727
+Skagit,State Senator,10,Republican,Barbara Bailey,9468
+Skagit,State Senator,10,Democratic,Angie Homola,7382
+Skagit,State Representative,10-1,Republican,Norma Smith,10880
+Skagit,State Representative,10-1,Libertarian,Michael Scott,4278
+Skagit,State Representative,10-2,Republican,Dave Hayes,9373
+Skagit,State Representative,10-2,Democratic,Doris Brevoort,7046
+Skagit,State Senator,39,Republican,Kirk Pearson,9245
+Skagit,State Representative,39-1,Republican,Dan Kristiansen,7174
+Skagit,State Representative,39-1,Democrat,Linda M. Wright,4565
+Skagit,State Representative,39-2,Republican,John Koster,7141
+Skagit,State Representative,39-2,Democratic,Ronda Metcalf,4633
+Skagit,State Senator,40,Democratic,Kevin Ranker,14061
+Skagit,State Senator,40,Republican,Daniel R. Miller,11269
+Skagit,State Representative,40-1,Democratic,Kristine Lytton,17659
+Skagit,State Representative,40-2,Democratic,Jeff Morris,17293
+Skamania,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,2232
+Skamania,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,2928
+Skamania,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,13
+Skamania,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,4
+Skamania,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,139
+Skamania,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,38
+Skamania,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,285
+Skamania,U.S. Senator,NA,Democratic,Patty Murray,2688
+Skamania,U.S. Senator,NA,Republican,Chris Vance,2945
+Skamania,U.S. Representative,3,Republican,Jaime Herrera Beutler,3507
+Skamania,U.S. Representative,3,Democratic,Jim Moeller,2069
+Skamania,Governor,NA,Democratic,Jay Inslee,2476
+Skamania,Governor,NA,Republican,Bill Bryant,3094
+Skamania,Lt. Governor,NA,Democratic,Cyrus Habib,2333
+Skamania,Lt. Governor,NA,Republican,Marty McClendon,3058
+Skamania,Secretary of State,NA,Republican,Kim Wyman,3343
+Skamania,Secretary of State,NA,Democratic,Tina Podlodowski,2043
+Skamania,State Treasurer,NA,Republican,Duane Davidson,2753
+Skamania,State Treasurer,NA,Republican,Michael Waite,1936
+Skamania,State Auditor,NA,Republican,Mark Miloscia,2962
+Skamania,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,2343
+Skamania,Attorney General,NA,Democratic,Bob Ferguson,2847
+Skamania,Attorney General,NA,Libertarian,Joshua B. Trumbull,2188
+Skamania,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,3115
+Skamania,Commissioner of Public Lands,NA,Democratic,Hilary Franz,2248
+Skamania,Superintendent of Public Instruction,NA,NA,Erin Jones,2122
+Skamania,Superintendent of Public Instruction,NA,NA,Chris Reykdal,2228
+Skamania,Insurance Commissioner,NA,Democratic,Mike Kreidler,2379
+Skamania,Insurance Commissioner,NA,Republican,Richard Schrock,2842
+Skamania,State Senator,14,Republican,Curtis King,2591
+Skamania,State Senator,14,Independent GOP,Amanda Richards,2266
+Skamania,State Representative,14-1,Republican,Norm Johnson,3175
+Skamania,State Representative,14-1,Democratic,Susan Soto Palmer,2120
+Skamania,State Representative,14-2,Republican,Gina McCabe,3379
+Skamania,State Representative,14-2,Democratic,John (Eric) Adams,1901
+Snohomish,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,185227
+Snohomish,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,128255
+Snohomish,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,474
+Snohomish,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,358
+Snohomish,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,6396
+Snohomish,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,2116
+Snohomish,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,19347
+Snohomish,U.S. Senator,NA,Democratic,Patty Murray,201915
+Snohomish,U.S. Senator,NA,Republican,Chris Vance,148325
+Snohomish,U.S. Representative,1,Democratic,Suzan DelBene,67546
+Snohomish,U.S. Representative,1,Republican,Robert J. Sutherland,64275
+Snohomish,U.S. Representative,2,Democratic,Rick Larsen,114975
+Snohomish,U.S. Representative,2,Republican,Marc Hennemann,68508
+Snohomish,U.S. Representative,7,Democratic,Pramila Jayapal,11738
+Snohomish,U.S. Representative,7,Democratic,Brady Pinero Walkinshaw,12649
+Snohomish,Governor,NA,Democratic,Jay Inslee,182544
+Snohomish,Governor,NA,Republican,Bill Bryant,166770
+Snohomish,Lt. Governor,NA,Democratic,Cyrus Habib,181853
+Snohomish,Lt. Governor,NA,Republican,Marty McClendon,156067
+Snohomish,Secretary of State,NA,Republican,Kim Wyman,189420
+Snohomish,Secretary of State,NA,Democratic,Tina Podlodowski,149325
+Snohomish,State Treasurer,NA,Republican,Duane Davidson,165574
+Snohomish,State Treasurer,NA,Republican,Michael Waite,134147
+Snohomish,State Auditor,NA,Republican,Mark Miloscia,161752
+Snohomish,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,167967
+Snohomish,Attorney General,NA,Democratic,Bob Ferguson,212974
+Snohomish,Attorney General,NA,Libertarian,Joshua B. Trumbull,112640
+Snohomish,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,159412
+Snohomish,Commissioner of Public Lands,NA,Democratic,Hilary Franz,172034
+Snohomish,Superintendent of Public Instruction,NA,NA,Erin Jones,144084
+Snohomish,Superintendent of Public Instruction,NA,NA,Chris Reykdal,145528
+Snohomish,Insurance Commissioner,NA,Democratic,Mike Kreidler,187135
+Snohomish,Insurance Commissioner,NA,Republican,Richard Schrock,139785
+Snohomish,State Senator,1,Republican,Mindie Wirth,22395
+Snohomish,State Senator,1,Democratic,Guy Palumbo,28003
+Snohomish,State Representative,1-1,Democratic,Derek Stanford,29691
+Snohomish,State Representative,1-1,Republican,Neil Thannisch,20213
+Snohomish,State Representative,1-2,Republican,Jim Langston,23171
+Snohomish,State Representative,1-2,Democratic,Shelley Kloba,26745
+Snohomish,State Senator,10,Republican,Barbara Bailey,9690
+Snohomish,State Senator,10,Democratic,Angie Homola,5536
+Snohomish,State Representative,10-1,Republican,Norma Smith,10227
+Snohomish,State Representative,10-1,Libertarian,Michael Scott,4238
+Snohomish,State Representative,10-2,Republican,Dave Hayes,10051
+Snohomish,State Representative,10-2,Democratic,Doris Brevoort,4992
+Snohomish,State Representative,21-1,Democratic,Strom Peterson,43184
+Snohomish,State Representative,21-1,Libertarian,Alex Hels,16639
+Snohomish,State Representative,21-2,Democratic,Lillian Ortiz-Self,38170
+Snohomish,State Representative,21-2,Republican,Jeff Scherrer,23466
+Snohomish,State Representative,32-1,Democratic,Cindy Ryu,20979
+Snohomish,State Representative,32-1,Republican,Alvin Rutledge,8759
+Snohomish,State Representative,32-2,Democratic,Ruth Kagi,19653
+Snohomish,State Representative,32-2,Republican,David D. Schirle,10042
+Snohomish,State Representative,38-1,Democratic,June Robinson,41895
+Snohomish,State Representative,38-2,Democratic,Mike Sells,31672
+Snohomish,State Representative,38-2,Independent,Bert Johnson,19129
+Snohomish,State Senator,39,Republican,Kirk Pearson,41514
+Snohomish,State Representative,39-1,Republican,Dan Kristiansen,30206
+Snohomish,State Representative,39-1,Democrat,Linda M. Wright,18619
+Snohomish,State Representative,39-2,Republican,John Koster,30002
+Snohomish,State Representative,39-2,Democratic,Ronda Metcalf,19079
+Snohomish,State Representative,44-1,Democratic,John Lovick,36836
+Snohomish,State Representative,44-1,Republican,Janice Huxford,34026
+Snohomish,State Representative,44-2,Republican,Mark Harmsworth,38138
+Snohomish,State Representative,44-2,Democratic,Katrina Ondracek,31773
+Spokane,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,93767
+Spokane,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,113435
+Spokane,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,346
+Spokane,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,243
+Spokane,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,4185
+Spokane,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,2043
+Spokane,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,13227
+Spokane,U.S. Senator,NA,Democratic,Patty Murray,113717
+Spokane,U.S. Senator,NA,Republican,Chris Vance,117197
+Spokane,U.S. Representative,5,Republican,Cathy McMorris Rodgers,133752
+Spokane,U.S. Representative,5,Democratic,Joe Pakootas,96695
+Spokane,Governor,NA,Democratic,Jay Inslee,106009
+Spokane,Governor,NA,Republican,Bill Bryant,124576
+Spokane,Lt. Governor,NA,Democratic,Cyrus Habib,94838
+Spokane,Lt. Governor,NA,Republican,Marty McClendon,128052
+Spokane,Secretary of State,NA,Republican,Kim Wyman,141818
+Spokane,Secretary of State,NA,Democratic,Tina Podlodowski,80092
+Spokane,State Treasurer,NA,Republican,Duane Davidson,116043
+Spokane,State Treasurer,NA,Republican,Michael Waite,82693
+Spokane,State Auditor,NA,Republican,Mark Miloscia,123279
+Spokane,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,95689
+Spokane,Attorney General,NA,Democratic,Bob Ferguson,121452
+Spokane,Attorney General,NA,Libertarian,Joshua B. Trumbull,90240
+Spokane,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,131038
+Spokane,Commissioner of Public Lands,NA,Democratic,Hilary Franz,89715
+Spokane,Superintendent of Public Instruction,NA,NA,Erin Jones,99125
+Spokane,Superintendent of Public Instruction,NA,NA,Chris Reykdal,92086
+Spokane,Insurance Commissioner,NA,Democratic,Mike Kreidler,100839
+Spokane,Insurance Commissioner,NA,Republican,Richard Schrock,116194
+Spokane,State Senator,3,Democratic,Andy Billig,33777
+Spokane,State Senator,3,Libertarian,James R. Apker,16395
+Spokane,State Representative,3-1,Democratic,Marcus Riccelli,33484
+Spokane,State Representative,3-1,Libertarian,Randy McGlenn II,16260
+Spokane,State Representative,3-2,Democratic,Timm Ormsby,31878
+Spokane,State Representative,3-2,Republican,Laura Carder,19460
+Spokane,State Senator,4,Republican,Mike Padden,55715
+Spokane,State Representative,4-1,Republican,Matt Shea,43914
+Spokane,State Representative,4-1,Democratic,Scott V. Stucker,24021
+Spokane,State Representative,4-2,Republican,Bob McCaslin,55755
+Spokane,State Representative,6-1,Democratic,Lynnette Vehrs,30421
+Spokane,State Representative,6-1,Republican,Mike Volz,37702
+Spokane,State Representative,6-2,Republican,Jeff Holy,42948
+Spokane,State Representative,6-2,Democratic,Shar Lichty,25302
+Spokane,State Representative,7-1,Republican,Shelly Short,22577
+Spokane,State Representative,7-2,Republican,Joel Kretz,19536
+Spokane,State Representative,7-2,Libertarian,Mike Foster,6268
+Spokane,State Senator,9,G.O.P,Mark G. Schoesler,3852
+Spokane,State Representative,9-1,Republican,Mary Dye,3690
+Spokane,State Representative,9-1,Democratic,Jennifer Goulet,1032
+Spokane,State Representative,9-2,Republican,Joe Schmick,3953
+Stevens,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,5767
+Stevens,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,15161
+Stevens,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,31
+Stevens,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,23
+Stevens,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,307
+Stevens,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,254
+Stevens,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1134
+Stevens,U.S. Senator,NA,Democratic,Patty Murray,8150
+Stevens,U.S. Senator,NA,Republican,Chris Vance,14830
+Stevens,U.S. Representative,5,Republican,Cathy McMorris Rodgers,15562
+Stevens,U.S. Representative,5,Democratic,Joe Pakootas,7409
+Stevens,Governor,NA,Democratic,Jay Inslee,7148
+Stevens,Governor,NA,Republican,Bill Bryant,15851
+Stevens,Lt. Governor,NA,Democratic,Cyrus Habib,6133
+Stevens,Lt. Governor,NA,Republican,Marty McClendon,16047
+Stevens,Secretary of State,NA,Republican,Kim Wyman,16676
+Stevens,Secretary of State,NA,Democratic,Tina Podlodowski,5460
+Stevens,State Treasurer,NA,Republican,Duane Davidson,11514
+Stevens,State Treasurer,NA,Republican,Michael Waite,8320
+Stevens,State Auditor,NA,Republican,Mark Miloscia,15236
+Stevens,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,6617
+Stevens,Attorney General,NA,Democratic,Bob Ferguson,9632
+Stevens,Attorney General,NA,Libertarian,Joshua B. Trumbull,10770
+Stevens,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,16334
+Stevens,Commissioner of Public Lands,NA,Democratic,Hilary Franz,5815
+Stevens,Superintendent of Public Instruction,NA,NA,Erin Jones,8727
+Stevens,Superintendent of Public Instruction,NA,NA,Chris Reykdal,9355
+Stevens,Insurance Commissioner,NA,Democratic,Mike Kreidler,6770
+Stevens,Insurance Commissioner,NA,Republican,Richard Schrock,14808
+Stevens,State Representative,7-1,Republican,Shelly Short,18812
+Stevens,State Representative,7-2,Republican,Joel Kretz,16396
+Stevens,State Representative,7-2,Libertarian,Mike Foster,4516
+Thurston,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,68798
+Thurston,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,48624
+Thurston,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,203
+Thurston,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,187
+Thurston,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,3584
+Thurston,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,708
+Thurston,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,7306
+Thurston,U.S. Senator,NA,Democratic,Patty Murray,78158
+Thurston,U.S. Senator,NA,Republican,Chris Vance,52623
+Thurston,U.S. Representative,3,Republican,Jaime Herrera Beutler,3520
+Thurston,U.S. Representative,3,Democratic,Jim Moeller,1963
+Thurston,U.S. Representative,10,Democratic,Denny Heck,76604
+Thurston,U.S. Representative,10,Republican,Jim Postma,45599
+Thurston,Governor,NA,Democratic,Jay Inslee,71835
+Thurston,Governor,NA,Republican,Bill Bryant,59014
+Thurston,Lt. Governor,NA,Democratic,Cyrus Habib,69735
+Thurston,Lt. Governor,NA,Republican,Marty McClendon,56566
+Thurston,Secretary of State,NA,Republican,Kim Wyman,77292
+Thurston,Secretary of State,NA,Democratic,Tina Podlodowski,50743
+Thurston,State Treasurer,NA,Republican,Duane Davidson,61579
+Thurston,State Treasurer,NA,Republican,Michael Waite,48591
+Thurston,State Auditor,NA,Republican,Mark Miloscia,56918
+Thurston,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,66931
+Thurston,Attorney General,NA,Democratic,Bob Ferguson,83338
+Thurston,Attorney General,NA,Libertarian,Joshua B. Trumbull,38845
+Thurston,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,57619
+Thurston,Commissioner of Public Lands,NA,Democratic,Hilary Franz,67195
+Thurston,Superintendent of Public Instruction,NA,NA,Erin Jones,45776
+Thurston,Superintendent of Public Instruction,NA,NA,Chris Reykdal,67964
+Thurston,Insurance Commissioner,NA,Democratic,Mike Kreidler,77425
+Thurston,Insurance Commissioner,NA,Republican,Richard Schrock,47146
+Thurston,State Senator,2,Republican,Randi Becker,12582
+Thurston,State Senator,2,Democratic,Marilyn Rasmussen,9458
+Thurston,State Representative,2-1,Republican,Andrew Barkis,12013
+Thurston,State Representative,2-1,Independent Dem.,Amy Pivetta Hoffman,9676
+Thurston,State Representative,2-2,Republican,JT Wilcox,13559
+Thurston,State Representative,2-2,Democratic,Derek Maynes,8441
+Thurston,State Senator,20,Republican,John Braun,8573
+Thurston,State Representative,20-1,GOP,Richard DeBolt,8198
+Thurston,State Representative,20-2,Republican,Ed Orcutt,8485
+Thurston,State Senator,22,Democratic,Sam Hunt,45882
+Thurston,State Senator,22,NA,Steve Owens,22986
+Thurston,State Representative,22-1,Democratic,Laurie Dolan,46088
+Thurston,State Representative,22-1,Republican,Donald Austin,23405
+Thurston,State Representative,22-2,Democratic,Beth Doglio,52053
+Thurston,State Representative,35-1,Republican,Dan Griffey,10991
+Thurston,State Representative,35-1,Independent Dem.,Irene Bowling,9689
+Thurston,State Representative,35-2,Republican,Drew C. MacEwen,10399
+Thurston,State Representative,35-2,Independent Dem.,Craig Patti,10101
+Wahkiakum,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,832
+Wahkiakum,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,1344
+Wahkiakum,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,2
+Wahkiakum,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,1
+Wahkiakum,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,50
+Wahkiakum,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,18
+Wahkiakum,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,111
+Wahkiakum,U.S. Senator,NA,Democratic,Patty Murray,1129
+Wahkiakum,U.S. Senator,NA,Republican,Chris Vance,1217
+Wahkiakum,U.S. Representative,3,Republican,Jaime Herrera Beutler,1522
+Wahkiakum,U.S. Representative,3,Democratic,Jim Moeller,810
+Wahkiakum,Governor,NA,Democratic,Jay Inslee,941
+Wahkiakum,Governor,NA,Republican,Bill Bryant,1413
+Wahkiakum,Lt. Governor,NA,Democratic,Cyrus Habib,868
+Wahkiakum,Lt. Governor,NA,Republican,Marty McClendon,1339
+Wahkiakum,Secretary of State,NA,Republican,Kim Wyman,1429
+Wahkiakum,Secretary of State,NA,Democratic,Tina Podlodowski,780
+Wahkiakum,State Treasurer,NA,Republican,Duane Davidson,1001
+Wahkiakum,State Treasurer,NA,Republican,Michael Waite,857
+Wahkiakum,State Auditor,NA,Republican,Mark Miloscia,1248
+Wahkiakum,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,897
+Wahkiakum,Attorney General,NA,Democratic,Bob Ferguson,1195
+Wahkiakum,Attorney General,NA,Libertarian,Joshua B. Trumbull,868
+Wahkiakum,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,1362
+Wahkiakum,Commissioner of Public Lands,NA,Democratic,Hilary Franz,826
+Wahkiakum,Superintendent of Public Instruction,NA,NA,Erin Jones,770
+Wahkiakum,Superintendent of Public Instruction,NA,NA,Chris Reykdal,1059
+Wahkiakum,Insurance Commissioner,NA,Democratic,Mike Kreidler,932
+Wahkiakum,Insurance Commissioner,NA,Republican,Richard Schrock,1191
+Wahkiakum,State Senator,19,Democratic,Dean Takko,1301
+Wahkiakum,State Senator,19,Independent GOP,Sue Kuehl Pederson,992
+Wahkiakum,State Representative,19-1,Republican,Jim Walsh,1250
+Wahkiakum,State Representative,19-1,Democratic,Teresa Purcell,1020
+Wahkiakum,State Representative,19-2,Democratic,Brian E. Blake,1311
+Wahkiakum,State Representative,19-2,Republican,Jimi O'Hagan,964
+Walla Walla,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,9694
+Walla Walla,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,13651
+Walla Walla,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,41
+Walla Walla,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,28
+Walla Walla,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,386
+Walla Walla,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,184
+Walla Walla,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1435
+Walla Walla,U.S. Senator,NA,Democratic,Patty Murray,12645
+Walla Walla,U.S. Senator,NA,Republican,Chris Vance,12969
+Walla Walla,U.S. Representative,4,Republican,Dan Newhouse,989
+Walla Walla,U.S. Representative,4,Republican,Clint Didier,1260
+Walla Walla,U.S. Representative,5,Republican,Cathy McMorris Rodgers,14536
+Walla Walla,U.S. Representative,5,Democratic,Joe Pakootas,8633
+Walla Walla,Governor,NA,Democratic,Jay Inslee,10705
+Walla Walla,Governor,NA,Republican,Bill Bryant,14880
+Walla Walla,Lt. Governor,NA,Democratic,Cyrus Habib,9758
+Walla Walla,Lt. Governor,NA,Republican,Marty McClendon,14806
+Walla Walla,Secretary of State,NA,Republican,Kim Wyman,16698
+Walla Walla,Secretary of State,NA,Democratic,Tina Podlodowski,7910
+Walla Walla,State Treasurer,NA,Republican,Duane Davidson,13379
+Walla Walla,State Treasurer,NA,Republican,Michael Waite,8526
+Walla Walla,State Auditor,NA,Republican,Mark Miloscia,14292
+Walla Walla,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,9868
+Walla Walla,Attorney General,NA,Democratic,Bob Ferguson,13403
+Walla Walla,Attorney General,NA,Libertarian,Joshua B. Trumbull,9681
+Walla Walla,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,15299
+Walla Walla,Commissioner of Public Lands,NA,Democratic,Hilary Franz,8995
+Walla Walla,Superintendent of Public Instruction,NA,NA,Erin Jones,11147
+Walla Walla,Superintendent of Public Instruction,NA,NA,Chris Reykdal,9878
+Walla Walla,Insurance Commissioner,NA,Democratic,Mike Kreidler,10313
+Walla Walla,Insurance Commissioner,NA,Republican,Richard Schrock,13564
+Walla Walla,State Senator,16,Republican,Maureen Walsh,20549
+Walla Walla,State Representative,16-1,Democratic,Rebecca Francik,9591
+Walla Walla,State Representative,16-1,Republican,William 'Bill' Jenkin,14664
+Walla Walla,State Representative,16-2,Republican,Terry R. Nealey,16710
+Walla Walla,State Representative,16-2,Democratic,Gary Downing,7871
+Whatcom,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,60340
+Whatcom,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,40599
+Whatcom,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,120
+Whatcom,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,151
+Whatcom,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,3005
+Whatcom,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,621
+Whatcom,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,4837
+Whatcom,U.S. Senator,NA,Democratic,Patty Murray,65830
+Whatcom,U.S. Senator,NA,Republican,Chris Vance,44924
+Whatcom,U.S. Representative,1,Democratic,Suzan DelBene,24440
+Whatcom,U.S. Representative,1,Republican,Robert J. Sutherland,31395
+Whatcom,U.S. Representative,2,Democratic,Rick Larsen,40963
+Whatcom,U.S. Representative,2,Republican,Marc Hennemann,12655
+Whatcom,Governor,NA,Democratic,Jay Inslee,62634
+Whatcom,Governor,NA,Republican,Bill Bryant,47953
+Whatcom,Lt. Governor,NA,Democratic,Cyrus Habib,60786
+Whatcom,Lt. Governor,NA,Republican,Marty McClendon,46775
+Whatcom,Secretary of State,NA,Republican,Kim Wyman,53932
+Whatcom,Secretary of State,NA,Democratic,Tina Podlodowski,53581
+Whatcom,State Treasurer,NA,Republican,Duane Davidson,60564
+Whatcom,State Treasurer,NA,Republican,Michael Waite,33011
+Whatcom,State Auditor,NA,Republican,Mark Miloscia,47409
+Whatcom,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,57669
+Whatcom,Attorney General,NA,Democratic,Bob Ferguson,68377
+Whatcom,Attorney General,NA,Libertarian,Joshua B. Trumbull,32418
+Whatcom,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,47436
+Whatcom,Commissioner of Public Lands,NA,Democratic,Hilary Franz,58346
+Whatcom,Superintendent of Public Instruction,NA,NA,Erin Jones,50249
+Whatcom,Superintendent of Public Instruction,NA,NA,Chris Reykdal,39286
+Whatcom,Insurance Commissioner,NA,Democratic,Mike Kreidler,61275
+Whatcom,Insurance Commissioner,NA,Republican,Richard Schrock,42783
+Whatcom,State Senator,40,Democratic,Kevin Ranker,25309
+Whatcom,State Senator,40,Republican,Daniel R. Miller,9098
+Whatcom,State Representative,40-1,Democratic,Kristine Lytton,28068
+Whatcom,State Representative,40-2,Democratic,Jeff Morris,27464
+Whatcom,State Representative,42-1,Republican,Luanne Van Werven,39184
+Whatcom,State Representative,42-1,Democratic,Sharlaine LaClair,32565
+Whatcom,State Representative,42-2,Republican,Vincent Buys,41054
+Whatcom,State Representative,42-2,Democratic,Tracy Atwood,29853
+Whitman,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,8146
+Whitman,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,7403
+Whitman,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,24
+Whitman,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,23
+Whitman,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,317
+Whitman,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,165
+Whitman,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,1227
+Whitman,U.S. Senator,NA,Democratic,Patty Murray,9527
+Whitman,U.S. Senator,NA,Republican,Chris Vance,8040
+Whitman,U.S. Representative,5,Republican,Cathy McMorris Rodgers,9312
+Whitman,U.S. Representative,5,Democratic,Joe Pakootas,8181
+Whitman,Governor,NA,Democratic,Jay Inslee,8727
+Whitman,Governor,NA,Republican,Bill Bryant,8892
+Whitman,Lt. Governor,NA,Democratic,Cyrus Habib,8179
+Whitman,Lt. Governor,NA,Republican,Marty McClendon,8729
+Whitman,Secretary of State,NA,Republican,Kim Wyman,9969
+Whitman,Secretary of State,NA,Democratic,Tina Podlodowski,6913
+Whitman,State Treasurer,NA,Republican,Duane Davidson,8317
+Whitman,State Treasurer,NA,Republican,Michael Waite,6047
+Whitman,State Auditor,NA,Republican,Mark Miloscia,8748
+Whitman,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,7779
+Whitman,Attorney General,NA,Democratic,Bob Ferguson,9894
+Whitman,Attorney General,NA,Libertarian,Joshua B. Trumbull,5955
+Whitman,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,9075
+Whitman,Commissioner of Public Lands,NA,Democratic,Hilary Franz,7565
+Whitman,Superintendent of Public Instruction,NA,NA,Erin Jones,7025
+Whitman,Superintendent of Public Instruction,NA,NA,Chris Reykdal,7288
+Whitman,Insurance Commissioner,NA,Democratic,Mike Kreidler,8314
+Whitman,Insurance Commissioner,NA,Republican,Richard Schrock,7941
+Whitman,State Senator,9,G.O.P,Mark G. Schoesler,12040
+Whitman,State Representative,9-1,Republican,Mary Dye,9283
+Whitman,State Representative,9-1,Democratic,Jennifer Goulet,7412
+Whitman,State Representative,9-2,Republican,Joe Schmick,12214
+Yakima,U.S. President/Vice President,NA,Democratic,Hillary Clinton / Tim Kaine,31291
+Yakima,U.S. President/Vice President,NA,Republican,Donald J. Trump / Michael R. Pence,41735
+Yakima,U.S. President/Vice President,NA,Socialist Workers,Alyson Kennedy / Osborne Hart,120
+Yakima,U.S. President/Vice President,NA,Socialism & Liberation,Gloria Estela La Riva / Eugene Puryear,111
+Yakima,U.S. President/Vice President,NA,Green,Jill Stein / Ajamu Baraka,774
+Yakima,U.S. President/Vice President,NA,Constitution,Darrell L. Castle / Scott N. Bradley,458
+Yakima,U.S. President/Vice President,NA,Libertarian,Gary Johnson / Bill Weld,3261
+Yakima,U.S. Senator,NA,Democratic,Patty Murray,37727
+Yakima,U.S. Senator,NA,Republican,Chris Vance,40612
+Yakima,U.S. Representative,4,Republican,Dan Newhouse,44880
+Yakima,U.S. Representative,4,Republican,Clint Didier,27945
+Yakima,Governor,NA,Democratic,Jay Inslee,35162
+Yakima,Governor,NA,Republican,Bill Bryant,43016
+Yakima,Lt. Governor,NA,Democratic,Cyrus Habib,30554
+Yakima,Lt. Governor,NA,Republican,Marty McClendon,45292
+Yakima,Secretary of State,NA,Republican,Kim Wyman,49972
+Yakima,Secretary of State,NA,Democratic,Tina Podlodowski,26027
+Yakima,State Treasurer,NA,Republican,Duane Davidson,37462
+Yakima,State Treasurer,NA,Republican,Michael Waite,29395
+Yakima,State Auditor,NA,Republican,Mark Miloscia,42382
+Yakima,State Auditor,NA,Democratic,Pat (Patrice) McCarthy,32347
+Yakima,Attorney General,NA,Democratic,Bob Ferguson,43216
+Yakima,Attorney General,NA,Libertarian,Joshua B. Trumbull,28902
+Yakima,Commissioner of Public Lands,NA,Republican,Steve McLaughlin,45463
+Yakima,Commissioner of Public Lands,NA,Democratic,Hilary Franz,29466
+Yakima,Superintendent of Public Instruction,NA,NA,Erin Jones,35817
+Yakima,Superintendent of Public Instruction,NA,NA,Chris Reykdal,30378
+Yakima,Insurance Commissioner,NA,Democratic,Mike Kreidler,33860
+Yakima,Insurance Commissioner,NA,Republican,Richard Schrock,40412
+Yakima,State Representative,13-1,Republican,Tom Dent,1553
+Yakima,State Representative,13-2,Republican,Matt Manweller,1383
+Yakima,State Representative,13-2,Democratic,Jordan Webb,379
+Yakima,State Senator,14,Republican,Curtis King,22564
+Yakima,State Senator,14,Independent GOP,Amanda Richards,12578
+Yakima,State Representative,14-1,Republican,Norm Johnson,24868
+Yakima,State Representative,14-1,Democratic,Susan Soto Palmer,11802
+Yakima,State Representative,14-2,Republican,Gina McCabe,25238
+Yakima,State Representative,14-2,Democratic,John (Eric) Adams,11037
+Yakima,State Representative,15-1,Republican,Bruce Chandler,30433
+Yakima,State Representative,15-2,Republican,David V. Taylor,21926
+Yakima,State Representative,15-2,Democrat,AJ Cooper,14491

--- a/cleaning/wa-cleaning.Rmd
+++ b/cleaning/wa-cleaning.Rmd
@@ -1,0 +1,102 @@
+---
+title: "openelections WA data cleaning"
+output: html_notebook
+---
+
+```{r packages}
+library(tidyverse)
+```
+Also calls: rio
+
+Get district info to use to convert county codes into counties in precinct parser
+```{r district-info}
+# found at https://www.sos.wa.gov/elections/research/Data-and-Statistics.aspx
+district_info <- rio::import('https://www.sos.wa.gov/_assets/elections/research/2016.12.07-Districts_Precincts.xlsx') %>% 
+    tbl_df()
+
+county_codes <- district_info %>% 
+    set_names(tolower) %>% 
+    select(countycode, county) %>% 
+    distinct()
+
+# rm(district_info)    # uncomment if you need the memory (dim: 173,309 x 9)
+```
+
+Set up file cleaning functions
+```{r cleaning-functions}
+clean_county <- . %>% 
+    set_names(tolower) %>%
+    filter(grepl("President|Senator|Representative|Governor|Secretary of State|State Treasurer|State Auditor|Attorney General|Commissioner of Public Lands|Superintendent of Public Instruction|Insurance Commissioner", race, ignore.case = TRUE)) %>% 
+    mutate(district = gsub('\\D+', '-', race), 
+           district = gsub('^-|-$', '', district), 
+           district = na_if(district, ''),
+           office = gsub('.*District \\d+ (\\D*)(?: Pos. \\d+)?$', '\\1', race), 
+           office = gsub('United States( U.S.)?', 'U.S.', office),
+           office = gsub('Washington State ', '', office), 
+           party = gsub('\\(Prefers | Party\\)| Party Nominees', '', party), 
+           party = gsub('&amp;', '&', party), 
+           party = gsub('&#39;', 'enden', party),
+           party = if_else(grepl('No Party|Non.Partisan|None', party), NA_character_, party)) %>% 
+    select(county, office, district, party, candidate, votes)
+
+clean_precinct <- function(precincts, counties_clean, county_codes) {
+    counties_clean <- counties_clean %>% select(candidate, party) %>% distinct()
+    
+    precincts %>% 
+        set_names(tolower) %>%
+        filter(grepl("President|Senator|Representative|Governor|Secretary of State|State Treasurer|State Auditor|Attorney General|Commissioner of Public Lands|Superintendent of Public Instruction|Insurance Commissioner", race, ignore.case = TRUE),
+               precinctname != 'Total') %>%    # also suspicious: `(none)`, siffix `(*)`
+        mutate(district = gsub('\\D+', '-', race), 
+               district = gsub('^-|-$', '', district), 
+               district = na_if(district, ''),
+               office = gsub('.*District \\d+ (\\D*)(?: Pos. \\d+)?$', '\\1', race), 
+               office = gsub('United States( U.S.)?', 'U.S.', office),
+               office = gsub('Washington State ', '', office)) %>% 
+        left_join(county_codes, by = 'countycode', na_matches = 'never') %>% 
+        left_join(counties_clean, by = 'candidate', na_matches = 'never') %>% 
+    select(county, precinct = precinctname, office, district, party, candidate, 
+           votes, precinct_code = precinctcode)
+}
+```
+
+Read the files directly from the web, clean them, and write each to a directory 
+for the corresponding year
+```{r read-clean-write}
+# Can be longer character vectors if data is similaly formatted. 
+# **Order of county and precinct elections must collate for proper joining.**
+county_urls <- 'http://results.vote.wa.gov/results/20161108/export/20161108_AllCounties.csv'
+precinct_urls <- 'http://results.vote.wa.gov/results/20161108/export/20161108_AllStatePrecincts.csv'
+
+# Make directories for each year present
+county_urls %>% 
+    basename() %>% 
+    substr(1, 4) %>% 
+    unique() %>% 
+    file.path('..', .) %>% 
+    walk(dir.create, showWarnings = FALSE)
+
+county_filenames <- county_urls %>% 
+    basename() %>% 
+    # To use on primaries, need type indicator or to run separately
+    sub('(\\d+).*', '\\1__wa__general__county.csv', .) %>% 
+    file.path('..', substr(., 1, 4), .)    # put in directory for year
+
+precinct_filenames <- precinct_urls %>% 
+    basename() %>% 
+    sub('(\\d+).*', '\\1__wa__general__precinct.csv', .) %>% 
+    file.path('..', substr(., 1, 4), .)
+
+# Read and clean county files. Write to memory for precinct joining.
+counties_clean <- county_urls %>% 
+    map(read_csv) %>% 
+    map(clean_county)
+
+# Write county files
+counties_clean %>% walk2(county_filenames, write_csv)
+
+# Read, clean, and write precinct files
+precinct_urls %>% 
+    map(read_csv) %>% 
+    map2(counties_clean, ~clean_precinct(.x, .y, county_codes)) %>% 
+    walk2(precinct_filenames, write_csv)    # write to disk immediately instead of memory
+```


### PR DESCRIPTION
Hi! This pull request adds cleaned data for the 2016 general elections by both county and precinct in a directory for the year (closes #3). It also includes the R script used to create them, which is built such that all that needs to be changed to apply it to new data is the vectors of URLs for county and precinct data, and if it’s for primary data, the filenames to be written.

I tried to make names clear and comment where complications could arise. It doesn’t standardize data much aside from obvious cruft. I did filter out `Total` precincts, and left `precinct_code` as a trailing column. County codes in precinct data are converted to county names (via another dataset from the SoS’s website) and are not exported.

It does join the cleaned county data to the precinct data to add parties (joining by candidate), which seems to work pretty well, but could be omitted by chopping out the join line, parameters, and references to `party`.

If it’s going to be run on new data, some verification is definitely in order; it’s hard to predict what oddities a different dataset may have.

I hope it’s helpful! Let me know if you’d like any alterations.

Best,
Edward